### PR TITLE
78 encrypted assertion

### DIFF
--- a/Kentor.AuthServices.Tests/CertificateNotFoundExceptionTests.cs
+++ b/Kentor.AuthServices.Tests/CertificateNotFoundExceptionTests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using FluentAssertions;
+
+namespace Kentor.AuthServices.Tests
+{
+    [TestClass]
+    public class CertificateNotFoundExceptionTests
+    {
+        [TestMethod]
+        public void CertificateNotFoundException_DefaultCtor()
+        {
+            ExceptionTestHelpers.TestDefaultCtor<CertificateNotFoundException>();
+        }
+
+        [TestMethod]
+        public void CertificateNotFoundException_SerializationCtor()
+        {
+            ExceptionTestHelpers.TestSerializationCtor<CertificateNotFoundException>();
+        }
+
+        [TestMethod]
+        public void CertificateNotFoundException_StringCtor()
+        {
+            var msg = "Message!";
+            var subject = new CertificateNotFoundException(msg);
+
+            subject.Message.Should().Be(msg);
+        }
+
+        [TestMethod]
+        public void CertificateNotFoundException_InnerExceptionCtor()
+        {
+            var inner = new Exception("inner");
+            var msg = "Message!";
+
+            var subject = new CertificateNotFoundException(msg, inner);
+
+            subject.Message.Should().Be(msg);
+            subject.InnerException.Should().Be(inner);
+        }
+    }
+}

--- a/Kentor.AuthServices.Tests/CertificatePrivateKeyNotFoundExceptionTests.cs
+++ b/Kentor.AuthServices.Tests/CertificatePrivateKeyNotFoundExceptionTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using Kentor.AuthServices.TestHelpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using FluentAssertions;
+
+namespace Kentor.AuthServices.Tests
+{
+    [TestClass]
+    public class CertificatePrivateKeyNotFoundExceptionTests
+    {
+        [TestMethod]
+        public void CertificateNotFoundException_DefaultCtor()
+        {
+            ExceptionTestHelpers.TestDefaultCtor<CertificatePrivateKeyNotFoundException>();
+        }
+
+        [TestMethod]
+        public void CertificatePrivateKeyNotFoundException_SerializationCtor()
+        {
+            ExceptionTestHelpers.TestSerializationCtor<CertificatePrivateKeyNotFoundException>();
+        }
+
+        [TestMethod]
+        public void CertificatePrivateKeyNotFoundException_CertificateCtor()
+        {
+            var certificate = SignedXmlHelper.TestCert;
+            var msg = String.Format("The private key for the certificate '{0}' was not found or access was denied.", certificate.SubjectName);
+            var subject = new CertificatePrivateKeyNotFoundException(certificate);
+
+            subject.Certificate.Should().Be(certificate);
+            subject.Message.Should().Be(msg);
+        }
+
+        [TestMethod]
+        public void CertificatePrivateKeyNotFoundException_StringCtor()
+        {
+            var certificate = SignedXmlHelper.TestCert;
+            var msg = "Message!";
+            var subject = new CertificatePrivateKeyNotFoundException(certificate, msg);
+
+            subject.Certificate.Should().Be(certificate);
+            subject.Message.Should().Be(msg);
+        }
+
+        [TestMethod]
+        public void CertificatePrivateKeyNotFoundException_InnerExceptionCtor()
+        {
+            var certificate = SignedXmlHelper.TestCert;
+            var inner = new Exception("inner");
+            var msg = "Message!";
+
+            var subject = new CertificatePrivateKeyNotFoundException(certificate, msg, inner);
+
+            subject.Certificate.Should().Be(certificate);
+            subject.Message.Should().Be(msg);
+            subject.InnerException.Should().Be(inner);
+        }
+    }
+}

--- a/Kentor.AuthServices/CertificateNotFoundException.cs
+++ b/Kentor.AuthServices/CertificateNotFoundException.cs
@@ -14,8 +14,7 @@ namespace Kentor.AuthServices
         /// </summary>
         public CertificateNotFoundException()
             : this("Certificate not found.")
-        {
-        }
+        { }
 
         /// <summary>
         /// Ctor
@@ -41,7 +40,6 @@ namespace Kentor.AuthServices
         /// <param name="context">Serialization context</param>
         protected CertificateNotFoundException(SerializationInfo info, StreamingContext context)
             : base(info, context)
-        {
-        }
+        { }
     }
 }

--- a/Kentor.AuthServices/CertificateNotFoundException.cs
+++ b/Kentor.AuthServices/CertificateNotFoundException.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Kentor.AuthServices
+{
+    /// <summary>
+    /// No saml response was found in the http request.
+    /// </summary>
+    [Serializable]
+    public class CertificateNotFoundException : AuthServicesException
+    {
+        /// <summary>
+        /// Default Ctor, setting message to a default.
+        /// </summary>
+        public CertificateNotFoundException()
+            : this("Certificate not found.")
+        {
+        }
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="message">Message of the exception.</param>
+        public CertificateNotFoundException(string message)
+            : base(message)
+        { }
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="message">Message of the exception.</param>
+        /// <param name="innerException">Inner exception.</param>
+        public CertificateNotFoundException(string message, Exception innerException)
+            :base(message, innerException)
+        { }
+
+        /// <summary>
+        /// Serialization Ctor
+        /// </summary>
+        /// <param name="info">Serialization info</param>
+        /// <param name="context">Serialization context</param>
+        protected CertificateNotFoundException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/Kentor.AuthServices/CertificatePrivateKeyNotFoundException.cs
+++ b/Kentor.AuthServices/CertificatePrivateKeyNotFoundException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Runtime.Serialization;
 using System.Security.Cryptography.X509Certificates;
 
@@ -21,13 +22,31 @@ namespace Kentor.AuthServices
         public CertificatePrivateKeyNotFoundException()
             : base("The private key for the certificate was not found or access was denied.")
         { }
-        
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="message">Message of the exception.</param>
+        /// <param name="innerException">Inner exception.</param>
+        public CertificatePrivateKeyNotFoundException(string message, Exception innerException)
+            : base(message, innerException)
+        { }
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="message">Message of the exception.</param>
+        public CertificatePrivateKeyNotFoundException(string message)
+            : base(message)
+        { }
+
         /// <summary>
         /// Default Ctor, setting message to a default.
         /// </summary>
         /// <param name="certificate">The certificate that the private key was not found or access was denied.</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0")]
         public CertificatePrivateKeyNotFoundException(X509Certificate2 certificate)
-            : this(certificate, String.Format("The private key for the certificate '{0}' was not found or access was denied.", certificate.SubjectName))
+            : this(certificate, String.Format(CultureInfo.InvariantCulture, "The private key for the certificate '{0}' was not found or access was denied.", certificate.SubjectName))
         { }
 
         /// <summary>
@@ -48,6 +67,11 @@ namespace Kentor.AuthServices
         public CertificatePrivateKeyNotFoundException(X509Certificate2 certificate, string message, Exception innerException)
             : base(message, innerException)
         {
+            if (certificate == null) 
+            {
+                throw new ArgumentNullException("certificate");
+            }
+
             Certificate = certificate;
         }
 
@@ -59,5 +83,19 @@ namespace Kentor.AuthServices
         protected CertificatePrivateKeyNotFoundException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         { }
+
+        /// <summary>
+        /// When overridden in a derived class, sets the <see cref="T:System.Runtime.Serialization.SerializationInfo"/> with information about the exception.
+        /// </summary>
+        /// <param name="info">The <see cref="T:System.Runtime.Serialization.SerializationInfo"/> that holds the serialized object data about the exception being thrown. </param><param name="context">The <see cref="T:System.Runtime.Serialization.StreamingContext"/> that contains contextual information about the source or destination. </param><exception cref="T:System.ArgumentNullException">The <paramref name="info"/> parameter is a null reference (Nothing in Visual Basic). </exception><filterpriority>2</filterpriority><PermissionSet><IPermission class="System.Security.Permissions.FileIOPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Read="*AllFiles*" PathDiscovery="*AllFiles*"/><IPermission class="System.Security.Permissions.SecurityPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Flags="SerializationFormatter"/></PermissionSet>
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            if (info == null) {
+                throw new ArgumentNullException("info");
+            }
+                
+            info.AddValue("Certificate", Certificate);
+        }
     }
 }

--- a/Kentor.AuthServices/CertificatePrivateKeyNotFoundException.cs
+++ b/Kentor.AuthServices/CertificatePrivateKeyNotFoundException.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Runtime.Serialization;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Kentor.AuthServices
+{
+    /// <summary>
+    /// No saml response was found in the http request.
+    /// </summary>
+    [Serializable]
+    public class CertificatePrivateKeyNotFoundException : AuthServicesException
+    {
+        /// <summary>
+        /// The certificate that the private key was not found or access was denied.
+        /// </summary>
+        public X509Certificate2 Certificate { get; private set; }
+
+        /// <summary>
+        /// Default Ctor, setting message to a default.
+        /// </summary>
+        public CertificatePrivateKeyNotFoundException()
+            : base("The private key for the certificate was not found or access was denied.")
+        {
+        }
+        
+        /// <summary>
+        /// Default Ctor, setting message to a default.
+        /// </summary>
+        /// <param name="certificate">The certificate that the private key was not found or access was denied.</param>
+        public CertificatePrivateKeyNotFoundException(X509Certificate2 certificate)
+            : this(certificate, String.Format("The private key for the certificate '{0}' was not found or access was denied.", certificate.SubjectName))
+        {
+        }
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="certificate">The certificate that the private key was not found or access was denied.</param>
+        /// <param name="message">Message of the exception.</param>
+        public CertificatePrivateKeyNotFoundException(X509Certificate2 certificate, string message)
+            : this(certificate, message, null)
+        {
+        }
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="certificate">The certificate that the private key was not found or access was denied.</param>
+        /// <param name="message">Message of the exception.</param>
+        /// <param name="innerException">Inner exception.</param>
+        public CertificatePrivateKeyNotFoundException(X509Certificate2 certificate, string message, Exception innerException)
+            : base(message, innerException)
+        {
+            Certificate = certificate;
+        }
+
+        /// <summary>
+        /// Serialization Ctor
+        /// </summary>
+        /// <param name="info">Serialization info</param>
+        /// <param name="context">Serialization context</param>
+        protected CertificatePrivateKeyNotFoundException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/Kentor.AuthServices/CertificatePrivateKeyNotFoundException.cs
+++ b/Kentor.AuthServices/CertificatePrivateKeyNotFoundException.cs
@@ -20,8 +20,7 @@ namespace Kentor.AuthServices
         /// </summary>
         public CertificatePrivateKeyNotFoundException()
             : base("The private key for the certificate was not found or access was denied.")
-        {
-        }
+        { }
         
         /// <summary>
         /// Default Ctor, setting message to a default.
@@ -29,8 +28,7 @@ namespace Kentor.AuthServices
         /// <param name="certificate">The certificate that the private key was not found or access was denied.</param>
         public CertificatePrivateKeyNotFoundException(X509Certificate2 certificate)
             : this(certificate, String.Format("The private key for the certificate '{0}' was not found or access was denied.", certificate.SubjectName))
-        {
-        }
+        { }
 
         /// <summary>
         /// Ctor
@@ -39,8 +37,7 @@ namespace Kentor.AuthServices
         /// <param name="message">Message of the exception.</param>
         public CertificatePrivateKeyNotFoundException(X509Certificate2 certificate, string message)
             : this(certificate, message, null)
-        {
-        }
+        { }
 
         /// <summary>
         /// Ctor
@@ -61,7 +58,6 @@ namespace Kentor.AuthServices
         /// <param name="context">Serialization context</param>
         protected CertificatePrivateKeyNotFoundException(SerializationInfo info, StreamingContext context)
             : base(info, context)
-        {
-        }
+        { }
     }
 }

--- a/Kentor.AuthServices/CertificateUtilities.cs
+++ b/Kentor.AuthServices/CertificateUtilities.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Security.Cryptography.X509Certificates;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Kentor.AuthServices
 {

--- a/Kentor.AuthServices/CertificateUtilities.cs
+++ b/Kentor.AuthServices/CertificateUtilities.cs
@@ -1,11 +1,78 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Kentor.AuthServices
 {
     class CertificateUtilities
     {
+        /// <summary>
+        /// Search for the specified certificate. If more than one certificate is found then an <see cref="InvalidOperationException"/> is thrown.
+        /// </summary>
+        /// <param name="names">The names of the stores to search</param>
+        /// <param name="locations">The locations in the certificate stores to search in.</param>
+        /// <param name="findType">The type of search or query to match on.</param>
+        /// <param name="value">The value to find.</param>
+        /// <param name="certificate">The certificate if found, null if not found or an exception is thrown.</param>
+        /// <returns>Treu if the certificate was found, false if otherwise.</returns>
+        public static bool TryGetCertificate(IEnumerable<StoreName> names, IEnumerable<StoreLocation> locations, X509FindType findType, string value, out X509Certificate2 certificate)
+        {
+            certificate = null;
+            if ((names == null) && (!names.Any())) {
+                return false;
+            }
+            if ((locations == null) && (! locations.Any())) {
+                return false;
+            }
+            
+            foreach (StoreName name in names) {
+                foreach (StoreLocation location in locations) {
+                    var store = new X509Store(name, location);
+                    store.Open(OpenFlags.ReadOnly);
+                    try {
+                        var certs = store.Certificates.Find(findType, value, false);
+                        if (certs.Count == 1) {
+                            certificate = certs[0];
+                            return (true);
+                        }
+                        if (certs.Count > 1) {
+                            throw new CertificateNotFoundException(
+                                string.Format(CultureInfo.InvariantCulture,
+                                "Finding cert through {0} in {1}:{2} with value {3} matched {4} certificates. A unique match is required.",
+                                findType, location, name, value, certs.Count));
+                        }
+                    } finally {
+                        store.Close();
+                    }
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Search for the specified certificate. If certificate is not found, then a <see cref="CertificateNotFoundException" /> is thrown. 
+        /// If more than one certificate is found then an <see cref="InvalidOperationException"/> is thrown.
+        /// </summary>
+        /// <param name="names">The names of the stores to search</param>
+        /// <param name="locations">The locations in the certificate stores to search in.</param>
+        /// <param name="findType">The type of search or query to match on.</param>
+        /// <param name="value">The value to find.</param>
+        /// <returns>The certificate if found. If not found, then a <see cref="CertificateNotFoundException" /> is thrown.</returns>
+        public static X509Certificate2 GetCertificate(IEnumerable<StoreName> names, IEnumerable<StoreLocation> locations, X509FindType findType, string value)
+        {
+            X509Certificate2 certificate;
+            if (TryGetCertificate(names, locations, findType, value, out certificate)) {
+                return certificate;
+            }
+
+            throw new CertificateNotFoundException(
+                        string.Format(CultureInfo.InvariantCulture,
+                        "Finding cert through {0} in [{1}]:[{2}] with value {3} matched no certificates.",
+                        findType, string.Join(",", names), string.Join(",", names), value));
+        }
+
         /// <summary>
         /// Search for the specified certificate. If more than one certificate is found then an <see cref="InvalidOperationException"/> is thrown.
         /// </summary>
@@ -17,26 +84,7 @@ namespace Kentor.AuthServices
         /// <returns>Treu if the certificate was found, false if otherwise.</returns>
         public static bool TryGetCertificate(StoreName name, StoreLocation location, X509FindType findType, string value, out X509Certificate2 certificate)
         {
-            certificate = null;
-
-            var store = new X509Store(name, location);
-            store.Open(OpenFlags.ReadOnly);
-            try {
-                var certs = store.Certificates.Find(findType, value, false);
-                if (certs.Count == 1) {
-                    certificate = certs[0];
-                    return (true);
-                }
-                if (certs.Count > 1) {
-                    throw new CertificateNotFoundException(
-                        string.Format(CultureInfo.InvariantCulture,
-                        "Finding cert through {0} in {1}:{2} with value {3} matched {4} certificates. A unique match is required.",
-                        findType, location, name, value, certs.Count));
-                }
-            } finally {
-                store.Close();
-            }
-            return false;
+            return TryGetCertificate(new[] { name }, new[] { location }, findType, value, out certificate);
         }
 
         /// <summary>

--- a/Kentor.AuthServices/CertificateUtilities.cs
+++ b/Kentor.AuthServices/CertificateUtilities.cs
@@ -20,30 +20,39 @@ namespace Kentor.AuthServices
         public static bool TryGetCertificate(IEnumerable<StoreName> names, IEnumerable<StoreLocation> locations, X509FindType findType, string value, out X509Certificate2 certificate)
         {
             certificate = null;
-            if ((names == null) && (!names.Any())) {
+            if ((names == null) && (!names.Any())) 
+            {
                 return false;
             }
-            if ((locations == null) && (! locations.Any())) {
+            if ((locations == null) && (! locations.Any())) 
+            {
                 return false;
             }
             
-            foreach (StoreName name in names) {
-                foreach (StoreLocation location in locations) {
+            foreach (StoreName name in names) 
+            {
+                foreach (StoreLocation location in locations) 
+                {
                     var store = new X509Store(name, location);
                     store.Open(OpenFlags.ReadOnly);
-                    try {
+                    try 
+                    {
                         var certs = store.Certificates.Find(findType, value, false);
-                        if (certs.Count == 1) {
+                        if (certs.Count == 1) 
+                        {
                             certificate = certs[0];
                             return (true);
                         }
-                        if (certs.Count > 1) {
+                        if (certs.Count > 1) 
+                        {
                             throw new CertificateNotFoundException(
                                 string.Format(CultureInfo.InvariantCulture,
                                 "Finding cert through {0} in {1}:{2} with value {3} matched {4} certificates. A unique match is required.",
                                 findType, location, name, value, certs.Count));
                         }
-                    } finally {
+                    } 
+                    finally 
+                    {
                         store.Close();
                     }
                 }
@@ -63,7 +72,8 @@ namespace Kentor.AuthServices
         public static X509Certificate2 GetCertificate(IEnumerable<StoreName> names, IEnumerable<StoreLocation> locations, X509FindType findType, string value)
         {
             X509Certificate2 certificate;
-            if (TryGetCertificate(names, locations, findType, value, out certificate)) {
+            if (TryGetCertificate(names, locations, findType, value, out certificate)) 
+            {
                 return certificate;
             }
 
@@ -99,7 +109,8 @@ namespace Kentor.AuthServices
         public static X509Certificate2 GetCertificate(StoreName name, StoreLocation location, X509FindType findType, string value)
         {
             X509Certificate2 certificate;
-            if (TryGetCertificate(name, location, findType, value, out certificate)) {
+            if (TryGetCertificate(name, location, findType, value, out certificate))
+            {
                 return certificate;
             }
             

--- a/Kentor.AuthServices/CertificateUtilities.cs
+++ b/Kentor.AuthServices/CertificateUtilities.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kentor.AuthServices
+{
+    class CertificateUtilities
+    {
+        /// <summary>
+        /// Search for the specified certificate. If more than one certificate is found then an <see cref="InvalidOperationException"/> is thrown.
+        /// </summary>
+        /// <param name="name">Name of the store to search.</param>
+        /// <param name="location">The location in the certificate store to search in.</param>
+        /// <param name="findType">The type of search or query to match on.</param>
+        /// <param name="value">The value to find.</param>
+        /// <param name="certificate">The certificate if found, null if not found or an exception is thrown.</param>
+        /// <returns>Treu if the certificate was found, false if otherwise.</returns>
+        public static bool TryGetCertificate(StoreName name, StoreLocation location, X509FindType findType, string value, out X509Certificate2 certificate)
+        {
+            certificate = null;
+
+            var store = new X509Store(name, location);
+            store.Open(OpenFlags.ReadOnly);
+            try {
+                var certs = store.Certificates.Find(findType, value, false);
+                if (certs.Count == 1) {
+                    certificate = certs[0];
+                    return (true);
+                }
+                if (certs.Count > 1) {
+                    throw new CertificateNotFoundException(
+                        string.Format(CultureInfo.InvariantCulture,
+                        "Finding cert through {0} in {1}:{2} with value {3} matched {4} certificates. A unique match is required.",
+                        findType, location, name, value, certs.Count));
+                }
+            } finally {
+                store.Close();
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Search for the specified certificate. If certificate is not found, then a <see cref="CertificateNotFoundException" /> is thrown. 
+        /// If more than one certificate is found then an <see cref="InvalidOperationException"/> is thrown.
+        /// </summary>
+        /// <param name="name">Name of the store to search.</param>
+        /// <param name="location">The location in the certificate store to search in.</param>
+        /// <param name="findType">The type of search or query to match on.</param>
+        /// <param name="value">The value to find.</param>
+        /// <returns>The certificate if found. If not found, then a <see cref="CertificateNotFoundException" /> is thrown.</returns>
+        public static X509Certificate2 GetCertificate(StoreName name, StoreLocation location, X509FindType findType, string value)
+        {
+            X509Certificate2 certificate;
+            if (TryGetCertificate(name, location, findType, value, out certificate)) {
+                return certificate;
+            }
+            
+            throw new CertificateNotFoundException(
+                        string.Format(CultureInfo.InvariantCulture,
+                        "Finding cert through {0} in {1}:{2} with value {3} matched no certificates.",
+                        findType, location, name, value));
+        }
+    }
+}

--- a/Kentor.AuthServices/Configuration/CertificateElement.cs
+++ b/Kentor.AuthServices/Configuration/CertificateElement.cs
@@ -96,26 +96,7 @@ namespace Kentor.AuthServices.Configuration
             }
             else
             {
-                var store = new X509Store(StoreName, StoreLocation);              
-                store.Open(OpenFlags.ReadOnly);
-                try
-                {
-                    var certs = store.Certificates.Find(X509FindType, FindValue, false);
-
-                    if (certs.Count != 1)
-                    {
-                        throw new InvalidOperationException(
-                            string.Format(CultureInfo.InvariantCulture, 
-                            "Finding cert through {0} in {1}:{2} with value {3} matched {4} certificates. A unique match is required.",
-                            X509FindType, StoreLocation, StoreName, FindValue, certs.Count));
-                    }
-
-                    return certs[0];
-                }
-                finally
-                {
-                    store.Close();
-                }
+                return CertificateUtilities.GetCertificate(StoreName, StoreLocation, X509FindType, FindValue);              
             }
         }
     }

--- a/Kentor.AuthServices/Kentor.AuthServices.csproj
+++ b/Kentor.AuthServices/Kentor.AuthServices.csproj
@@ -20,7 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <RunCodeAnalysis>false</RunCodeAnalysis>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Kentor.AuthServices.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\Debug\Kentor.AuthServices.XML</DocumentationFile>
     <CodeAnalysisIgnoreGeneratedCode>true</CodeAnalysisIgnoreGeneratedCode>

--- a/Kentor.AuthServices/Kentor.AuthServices.csproj
+++ b/Kentor.AuthServices/Kentor.AuthServices.csproj
@@ -20,9 +20,10 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <RunCodeAnalysis>false</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\Kentor.AuthServices.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\Debug\Kentor.AuthServices.XML</DocumentationFile>
+    <CodeAnalysisIgnoreGeneratedCode>true</CodeAnalysisIgnoreGeneratedCode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -54,11 +55,14 @@
     <Compile Include="AcsCommand.cs" />
     <Compile Include="AuthServicesException.cs" />
     <Compile Include="BadFormatSamlResponseException.cs" />
+    <Compile Include="CertificateUtilities.cs" />
     <Compile Include="ClaimsIdentityExtensions.cs" />
     <Compile Include="CommandResult.cs" />
     <Compile Include="Configuration\IdentityProviderCollection.cs" />
     <Compile Include="Configuration\IdentityProviderElement.cs" />
     <Compile Include="Configuration\CertificateElement.cs" />
+    <Compile Include="CertificateNotFoundException.cs" />
+    <Compile Include="CertificatePrivateKeyNotFoundException.cs" />
     <Compile Include="DateTimeExtensions.cs" />
     <Compile Include="Enumerator.cs" />
     <Compile Include="IdentityProvider.cs" />
@@ -79,6 +83,7 @@
     <Compile Include="Saml2Binding.cs" />
     <Compile Include="Saml2BindingType.cs" />
     <Compile Include="Saml2ConditionsExtensions.cs" />
+    <Compile Include="Saml2EncryptedAssertion.cs" />
     <Compile Include="Saml2Namespaces.cs" />
     <Compile Include="Saml2PostBinding.cs" />
     <Compile Include="Saml2RedirectBinding.cs" />

--- a/Kentor.AuthServices/Saml2EncryptedAssertion.cs
+++ b/Kentor.AuthServices/Saml2EncryptedAssertion.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections;
+using System.Globalization;
+using System.IdentityModel.Metadata;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography.Xml;
+using System.Text;
+using System.Xml;
+using Kentor.AuthServices.Configuration;
+
+namespace Kentor.AuthServices
+{
+    class Saml2EncryptedAssertion
+    {
+        /// <summary>
+        /// Interate through the <see cref="KeyInfo"/> looking for the first <see cref="KeyInfoEncryptedKey" /> type.
+        /// </summary>
+        /// <param name="keyInfo">The enumeration to process.</param>
+        /// <returns>The first <see cref="KeyInfoEncryptedKey" /> found in the collecion.</returns>
+        private static T GetKeyInfo<T>(KeyInfo keyInfo)
+        {
+            if (keyInfo == null) 
+            {
+                throw new ArgumentNullException("keyInfo", "The encrypted keyInfo cannot be null");
+            }
+
+            return keyInfo.OfType<T>().FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Gets the encryption algorithm to use for the specified encrypted key info.
+        /// </summary>
+        /// <param name="algorithm">The Xmldsig namespace for the algorithm.</param>
+        /// <returns>The <see cref="SymmetricAlgorithm"/> to use to decrypt the data.</returns>
+        private static SymmetricAlgorithm GetAlgorithm(string algorithm)
+        {
+            switch (algorithm) 
+            {
+                case "http://www.w3.org/2001/04/xmlenc#tripledes-cbc":
+                case "http://www.w3.org/2001/04/xmlenc#kw-tripledes": 
+                    {
+                        return new TripleDESCryptoServiceProvider();
+                    }
+
+                case "http://www.w3.org/2001/04/xmlenc#aes128-cbc":
+                case "http://www.w3.org/2001/04/xmlenc#aes192-cbc":
+                case "http://www.w3.org/2001/04/xmlenc#kw-aes128":
+                case "http://www.w3.org/2001/04/xmlenc#aes256-cbc":
+                case "http://www.w3.org/2001/04/xmlenc#kw-aes192":
+                case "http://www.w3.org/2001/04/xmlenc#kw-aes256": 
+                    {
+                        return new RijndaelManaged();                    
+                    }
+            }
+            
+            throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, 
+                                                              "An unknown encryption algorithm '{0}' was specified. Cannot decrypt the response.",
+                                                              algorithm));
+        }
+
+        /// <summary>
+        /// Find the local certificate with private key that matches the encrypted key info. 
+        /// </summary>
+        /// <param name="keyInfo">The key info to search for.</param>
+        /// <returns>
+        /// The matching x509 certificate from the local store that has a private key. 
+        /// If the certificate is not found, then an <see cref="CertificateNotFoundException"/> is thrown.
+        /// If the certificate is found, but a private key is not available, then an 
+        /// <see cref="CertificatePrivateKeyNotFoundException" /> is thrown.
+        /// </returns>
+        private static X509Certificate2 GetCertificateWithPrivateKey(KeyInfoEncryptedKey keyInfo)
+        {
+            if (keyInfo == null) 
+            {
+                throw new ArgumentNullException("keyInfo", "The encrypted keyInfo cannot be null");
+            }
+
+            KeyInfoX509Data x509DataKeyInfo = GetKeyInfo<KeyInfoX509Data>(keyInfo.EncryptedKey.KeyInfo);
+            X509Certificate2 keyCertificate = (X509Certificate2) x509DataKeyInfo.Certificates[0];
+            var thumbprint = keyCertificate.Thumbprint;
+            X509Certificate2 certificate = CertificateUtilities.GetCertificate(new[] { StoreName.My },
+                                                                               new[] { StoreLocation.LocalMachine, StoreLocation.CurrentUser },
+                                                                               X509FindType.FindByThumbprint,
+                                                                               thumbprint);
+            if (! certificate.HasPrivateKey) 
+            {
+                throw new CertificatePrivateKeyNotFoundException(certificate);
+            }
+            return (certificate);
+        }
+
+        /// <summary>
+        /// Checks to see if the specified document has an encrpted assertion.
+        /// </summary>
+        /// <param name="document">The document to inspect.</param>
+        /// <returns></returns>
+        public static bool IsEncrypted(XmlDocument document)
+        {
+            if ((document == null) || (document.DocumentElement == null)) 
+            {
+                throw new ArgumentNullException("document", "The xml document was null.");
+            }
+
+            bool isEncrypted = document.DocumentElement.ChildNodes.Cast<XmlNode>()
+                .Where(node => node.NodeType == XmlNodeType.Element && node.NamespaceURI == Saml2Namespaces.Saml2Name).Cast<XmlElement>()
+                .Any(xe => xe.LocalName == "EncryptedAssertion");
+            return isEncrypted;
+        }
+
+        /// <summary>
+        /// Decrypts the EncryptedAssertion contained within the XmlElement.
+        /// </summary>
+        /// <param name="element">The EncryptedAssertion element to decrypt.</param>
+        /// <returns>The decrypted element.</returns>
+        public static XmlElement Decrypt(XmlElement element)
+        {
+            if (element == null) 
+            {
+                return (null);
+            }
+            if (element.LocalName != "EncryptedAssertion")
+            {
+                return (element);
+            }
+
+            XmlElement data = element.ChildNodes.Cast<XmlElement>()
+                .FirstOrDefault(xe => xe.LocalName == "EncryptedData");
+
+            var encryptedData = new EncryptedData();
+            encryptedData.LoadXml(data);
+
+            KeyInfoEncryptedKey encryptedKeyInfo = GetKeyInfo<KeyInfoEncryptedKey>(encryptedData.KeyInfo);
+            X509Certificate2 certificate = GetCertificateWithPrivateKey(encryptedKeyInfo);
+
+            SymmetricAlgorithm algorithm = GetAlgorithm(encryptedData.EncryptionMethod.KeyAlgorithm);
+            algorithm.Key = (certificate.PrivateKey as RSACryptoServiceProvider).Decrypt(encryptedKeyInfo.EncryptedKey.CipherData.CipherValue, true);
+            algorithm.Padding = PaddingMode.ISO10126;
+            algorithm.Mode = CipherMode.CBC;
+
+            int ivSize = algorithm.BlockSize / 8;
+            byte[] iv = new byte[ivSize];
+            Buffer.BlockCopy(encryptedData.CipherData.CipherValue, 0, iv, 0, iv.Length);
+            using (ICryptoTransform decrTransform = algorithm.CreateDecryptor(algorithm.Key, iv)) 
+            {
+                byte[] plainText = decrTransform.TransformFinalBlock(encryptedData.CipherData.CipherValue, iv.Length,
+                                                                     encryptedData.CipherData.CipherValue.Length - iv.Length);
+
+                XmlDocument assertion = new XmlDocument();
+                assertion.LoadXml(UTF8Encoding.UTF8.GetString(plainText));
+                return (assertion.DocumentElement);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implementation of issue #78.

Summary
-------------
+ Refactored certification reading into helper class. 
+ Created custom exceptions for certificate handling. 
+ Created helper / static class to decrypt an EncryptedAssertion replacing the contents of the Saml2Response with the decrypted contents.

Questions
-------------
Due to the dependency on the Windows certificate store, I'm unsure how to proceed with writing unit tests without creating an unnecessary abstraction. The previous CertificateElement class didn't handle this code coverage either... are you OK with this?

Also unsure on how to proceed with testing of message decryption. If full testing is desired, then we need a test helper able to generate EncryptedAssertion messages. Does anything exist yet?