### PR TITLE
158 appveyor

### DIFF
--- a/Kentor.AuthServices.sln
+++ b/Kentor.AuthServices.sln
@@ -7,6 +7,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Kentor.AuthServices", "Kent
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E0C4834E-A7A9-476F-8F46-B2D533190872}"
 	ProjectSection(SolutionItems) = preProject
+		appveyor.yml = appveyor.yml
 		CodeCoverage.runsettings = CodeCoverage.runsettings
 		CONTRIBUTORS.txt = CONTRIBUTORS.txt
 		Kentor.AuthServices.ruleset = Kentor.AuthServices.ruleset

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,14 @@
+# Notes:
+#   - Minimal appveyor.yml file is an empty file. All sections are optional.
+#   - Indent each level of configuration with 2 spaces. Do not use tabs!
+#   - All section names are case-sensitive.
+#   - Section names should be unique on each level.
+
+#---------------------------------#
+#    environment configuration    #
+#---------------------------------#
+
+# scripts that are called at very beginning, before repo cloning
+init:
+# force windows line endings to make test strings depending on line break work
+  - git config --global core.autocrlf true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,10 @@ init:
 # force windows line endings to make test strings depending on line break work
   - git config --global core.autocrlf true
 
+# scripts to run before build
+before_build:
+  - nuget restore
+
 #---------------------------------#
 #       tests configuration       #
 #---------------------------------#

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,9 @@ init:
 before_build:
   - nuget restore
 
+cache:
+  - packages                     # preserve "packages" directory in the root of build folder to avoid repeated downloads for nuget restore
+
 #---------------------------------#
 #       tests configuration       #
 #---------------------------------#

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,3 +12,11 @@
 init:
 # force windows line endings to make test strings depending on line break work
   - git config --global core.autocrlf true
+
+#---------------------------------#
+#       tests configuration       #
+#---------------------------------#
+
+test:
+  assemblies:
+      - Kentor.AuthServices.Tests.dll

--- a/doc/Contributing.md
+++ b/doc/Contributing.md
@@ -67,6 +67,12 @@ sure that they work. To run the integration tests:
 * Open Kentor.AuthServices.IntegrationTests in a separate Visual Studio Instance.
 * Run all tests in the integrationtests solution.
 
+##Continous integration / build server
+Kentor.AuthServices contains configuration for [AppVeyor CI](|https://ci.appveyor.com/).
+
+You may set up a free build of all branches in your GitHub fork by signing up to AppVeyor 
+(preferably with your GitHub account) and then creating a new project for your GitHub fork.
+
 ##Branching
 To make a clean pull request, it is important to follow some git best practices. Nancy
 has an [excellent guide](https://github.com/NancyFx/Nancy/blob/master/CONTRIBUTING.md) that outlines


### PR DESCRIPTION
A bunch of fixes for running Kentor.AuthServices on AppVeyor for #158
 - Set up NuGet package restore on solution
 - Configure git for CRLF endings
 - Specify test assembly to not run VSPremium tests
 - Note about setting up AppVeyor for contributors

An AppVeyor project of my personal fork building this branch is available on https://ci.appveyor.com/project/albinsunnanbo/authservices