### PR TITLE
Support for multiple signing certificates in downloaded metadata (#105) + Fix for ValidateInResponseTo results in "The Saml2Response didn't pass validation" in a farm setup #98

### DIFF
--- a/Kentor.AuthServices/IdentityProvider.cs
+++ b/Kentor.AuthServices/IdentityProvider.cs
@@ -77,7 +77,7 @@ namespace Kentor.AuthServices
                 throw new ConfigurationErrorsException("Missing binding configuration on Idp " + EntityId.Id + ".");
             }
 
-            if (SigningKeys == null)
+            if (!SigningKeys.Any())
             {
                 throw new ConfigurationErrorsException("Missing signing certificate configuration on Idp " + EntityId.Id + ".");
             }

--- a/Kentor.AuthServices/IdentityProvider.cs
+++ b/Kentor.AuthServices/IdentityProvider.cs
@@ -1,4 +1,5 @@
-﻿using Kentor.AuthServices.Configuration;
+﻿using System.Collections.Generic;
+using Kentor.AuthServices.Configuration;
 using System;
 using System.Configuration;
 using System.Globalization;
@@ -46,11 +47,11 @@ namespace Kentor.AuthServices
             LoadMetadata = config.LoadMetadata;
             this.spOptions = spOptions;
 
-            var certificate = config.SigningCertificate.LoadCertificate();
+            var certificate = config.SigningCertificate.LoadCertificate(); // TODO: add support for multiple configured signing certificates
 
             if (certificate != null)
             {
-                signingKey = certificate.PublicKey.Key;
+                signingKeys.Add(certificate.PublicKey.Key);
             }
 
             try
@@ -76,7 +77,7 @@ namespace Kentor.AuthServices
                 throw new ConfigurationErrorsException("Missing binding configuration on Idp " + EntityId.Id + ".");
             }
 
-            if (SigningKey == null)
+            if (SigningKeys == null)
             {
                 throw new ConfigurationErrorsException("Missing signing certificate configuration on Idp " + EntityId.Id + ".");
             }
@@ -243,23 +244,18 @@ namespace Kentor.AuthServices
             return Saml2Binding.Get(Binding).Bind(request);
         }
 
-        private AsymmetricAlgorithm signingKey;
+      private List<AsymmetricAlgorithm> signingKeys = new List<AsymmetricAlgorithm>();
 
         /// <summary>
         /// The public key of the idp that is used to verify signatures of responses/assertions.
         /// </summary>
-        public AsymmetricAlgorithm SigningKey
+        public IList<AsymmetricAlgorithm> SigningKeys
         {
             get
             {
                 ReloadMetadataIfRequired();
-                return signingKey;
+                return signingKeys;
             }
-            set
-            {
-                signingKey = value;
-            }
-
         }
 
         object metadataLoadLock = new object();
@@ -325,14 +321,13 @@ namespace Kentor.AuthServices
             binding = Saml2Binding.UriToSaml2BindingType(ssoService.Binding);
             singleSignOnServiceUrl = ssoService.Location;
 
-            var key = idpDescriptor.Keys
-                .Where(k => k.Use == KeyType.Unspecified || k.Use == KeyType.Signing)
-                .SingleOrDefault();
+            signingKeys.Clear();
 
-            if (key != null)
+            var keys = idpDescriptor.Keys.Where(k => k.Use == KeyType.Unspecified || k.Use == KeyType.Signing);
+
+            foreach (var key in keys)
             {
-                signingKey = ((AsymmetricSecurityKey)key.KeyInfo.CreateKey())
-                    .GetAsymmetricAlgorithm(SignedXml.XmlDsigRSASHA1Url, false);
+              signingKeys.Add(((AsymmetricSecurityKey) key.KeyInfo.CreateKey()).GetAsymmetricAlgorithm(SignedXml.XmlDsigRSASHA1Url, false));
             }
         }
 

--- a/Kentor.AuthServices/Internal/PendingAuthnRequests.cs
+++ b/Kentor.AuthServices/Internal/PendingAuthnRequests.cs
@@ -1,40 +1,94 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.IdentityModel.Metadata;
+using System.IdentityModel.Services;
 using System.IdentityModel.Tokens;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
+using System.Web;
+using System.Web.Security;
+using Kentor.AuthServices.Configuration;
 
 namespace Kentor.AuthServices.Internal
 {
     static class PendingAuthnRequests
     {
-        private static readonly Dictionary<Saml2Id, StoredRequestState> pendingAuthnRequest = new Dictionary<Saml2Id, StoredRequestState>();
+      private const string CookieName = "AuthNRequest";
+      private const string CookieIdAttribute = "id";
+      private const string CookieIdpIdAttribute = "idpId";
+      private const string Purpose = "Initiator Verification";
 
-        internal static void Add(Saml2Id id, StoredRequestState idp)
+      internal static void Add(Saml2Id id, StoredRequestState idp)
+      {
+        var cookie = GetNewCookie();
+        cookie.Values[CookieIdAttribute] = Encrypt(id.Value);
+        cookie.Values[CookieIdpIdAttribute] = Encrypt(idp.Idp.Id);
+
+        HttpContext.Current.Response.Cookies.Add(cookie);
+      }
+
+      internal static bool TryRemove(Saml2Id id, out StoredRequestState idp)
+      {
+        var returnValue = false;
+        idp = null;
+
+        var cookie = HttpContext.Current.Request.Cookies[CookieName];
+
+        if (cookie != null)
         {
-            lock (pendingAuthnRequest)
-            {
-                if (pendingAuthnRequest.ContainsKey(id))
-                {
-                    throw new InvalidOperationException("AuthnRequest id can't be reused.");
-                }
-                pendingAuthnRequest.Add(id, idp);
-            }
+          var cookieId = Decrypt(cookie.Values[CookieIdAttribute]);
+          var cookieIdpId = Decrypt(cookie.Values[CookieIdpIdAttribute]);
+
+          if (id != null && cookieId == id.Value)
+          {
+            idp = new StoredRequestState(new EntityId(cookieIdpId), null); // TODO: returnUrl is left out here as it's not used. Possibly add it by also storing it into the cookie (or get it from config based in the id) or simply remove if from the stored state
+            returnValue = true;
+          }
+
+          // Cleanup
+          cookie = GetNewCookie();
+          cookie.Expires = DateTime.Now.AddDays(-1d);
+          HttpContext.Current.Response.Cookies.Add(cookie);
         }
 
-        internal static bool TryRemove(Saml2Id id, out StoredRequestState idp)
+        return returnValue;
+      }
+
+      private static HttpCookie GetNewCookie()
+      {
+        return new HttpCookie(CookieName)
         {
-            lock (pendingAuthnRequest)
-            {
-                if (id != null && pendingAuthnRequest.ContainsKey(id))
-                {
-                    idp = pendingAuthnRequest[id];
-                    return pendingAuthnRequest.Remove(id);
-                }
-                idp = null;
-                return false;
-            }
+          Path = String.Concat(HttpContext.Current.Request.ApplicationPath, KentorAuthServicesSection.Current.ModulePath),
+          HttpOnly = FederatedAuthentication.SessionAuthenticationModule.CookieHandler.HideFromClientScript,
+          Secure = FederatedAuthentication.SessionAuthenticationModule.CookieHandler.RequireSsl
+        };
+      }
+
+      private static string Encrypt(string value)
+      {
+        var unprotectedBytes = Encoding.UTF8.GetBytes(value);
+        var protectedBytes = MachineKey.Protect(unprotectedBytes, Purpose);
+
+        return Convert.ToBase64String(protectedBytes);
+      }
+
+      private static string Decrypt(string value)
+      {
+        var returnValue = String.Empty;
+
+        if (!String.IsNullOrEmpty(value))
+        {
+          try
+          {
+            var protectedBytes = Convert.FromBase64String(value);
+            var unprotectedBytes = MachineKey.Unprotect(protectedBytes, Purpose);
+            returnValue = unprotectedBytes != null ? Encoding.UTF8.GetString(unprotectedBytes) : String.Empty;
+          }
+          catch (Exception)
+          {
+            // TODO: logging / exception. Probable causes: tempering with cookie, or machine keys are not equal on each farm member
+          }
         }
+
+        return returnValue;
+      }
     }
 }

--- a/Kentor.AuthServices/SAML2P/Saml2Response.cs
+++ b/Kentor.AuthServices/SAML2P/Saml2Response.cs
@@ -10,7 +10,6 @@ using System.Xml;
 using Kentor.AuthServices.Configuration;
 using System.IdentityModel.Metadata;
 using System.Security.Cryptography;
-using System.IdentityModel.Services;
 using Kentor.AuthServices.Internal;
 
 namespace Kentor.AuthServices.Saml2P
@@ -341,20 +340,21 @@ namespace Kentor.AuthServices.Saml2P
 
         private void ValidateSignature(IOptions options)
         {
-            var idpKey = options.IdentityProviders[Issuer].SigningKey;
+            var idpKeys = options.IdentityProviders[Issuer].SigningKeys;
 
             // If the response message is signed, we check just this signature because the whole content has to be correct then
             var responseSignature = xmlDocument.DocumentElement["Signature", SignedXml.XmlDsigNamespaceUrl];
+
             if (responseSignature != null)
             {
-                CheckSignature(XmlDocument.DocumentElement, idpKey);
+              CheckSignature(XmlDocument.DocumentElement, idpKeys);
             }
             else
             {
                 // If the response message is not signed, all assersions have to be signed correctly
                 foreach (var assertionNode in AllAssertionElementNodes)
                 {
-                    CheckSignature(assertionNode, idpKey);
+                  CheckSignature(assertionNode, idpKeys);
                 }
             }
         }
@@ -368,8 +368,8 @@ namespace Kentor.AuthServices.Saml2P
 
         /// <summary>Checks the signature.</summary>
         /// <param name="signedRootElement">The signed root element.</param>
-        /// <param name="idpKey">The assymetric key of the algorithm.</param>
-        private static void CheckSignature(XmlElement signedRootElement, AsymmetricAlgorithm idpKey)
+        /// <param name="idpKeys">A list containing one ore more assymetric keys of a algorithm.</param>
+        private static void CheckSignature(XmlElement signedRootElement, IList<AsymmetricAlgorithm> idpKeys)
         {
             var xmlDocument = new XmlDocument { PreserveWhitespace = true };
             xmlDocument.LoadXml(signedRootElement.OuterXml);
@@ -411,9 +411,16 @@ namespace Kentor.AuthServices.Saml2P
                 }
             }
 
-            if (!signedXml.CheckSignature(idpKey))
+            var validSignature = false;
+
+            for (var i = 0; !validSignature && i < idpKeys.Count; i++)
             {
-                throw new Saml2ResponseFailedValidationException("Signature validation failed on SAML response or contained assertion.");
+              validSignature = signedXml.CheckSignature(idpKeys[i]);
+            }
+
+            if (!validSignature)
+            {
+              throw new Saml2ResponseFailedValidationException("Signature validation failed on SAML response or contained assertion.");
             }
         }
 

--- a/Kentor.AuthServices/SAML2P/Saml2Response.cs
+++ b/Kentor.AuthServices/SAML2P/Saml2Response.cs
@@ -411,12 +411,7 @@ namespace Kentor.AuthServices.Saml2P
                 }
             }
 
-            var validSignature = false;
-
-            for (var i = 0; !validSignature && i < idpKeys.Count; i++)
-            {
-              validSignature = signedXml.CheckSignature(idpKeys[i]);
-            }
+            var validSignature = idpKeys.Any(signedXml.CheckSignature);
 
             if (!validSignature)
             {

--- a/Kentor.AuthServices/StoredRequestState.cs
+++ b/Kentor.AuthServices/StoredRequestState.cs
@@ -1,20 +1,15 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IdentityModel.Metadata;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Kentor.AuthServices
 {
     /// <summary>
     /// Stored data for each PendingAuthnRequest
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "AuthnRequest")] // AuthnRequest is already in dictionary
     public class StoredRequestState
     {
         /// <summary>
-        /// Creates a PendingAuthnRequestData
+        /// Creates a StoredRequestState
         /// </summary>
         /// <param name="idp">The EntityId of the IDP the request was sent to</param>
         /// <param name="returnUrl">The Url to redirect back to after a succesful login</param>
@@ -25,7 +20,7 @@ namespace Kentor.AuthServices
         }
 
         /// <summary>
-        /// Creates a PendingAuthnRequestData
+        /// Creates a StoredRequestState
         /// </summary>
         /// <param name="idp">The EntityId of the IDP the request was sent to</param>
         /// <param name="returnUrl">The Url to redirect back to after a succesful login</param>


### PR DESCRIPTION
Exisiting code is altered to fix issue reported in #190.  
- Kentor.AuthServices/IdentityProvider.cs
- Kentor.AuthServices/SAML2P/Saml2Response.cs

Fix for ValidateInResponseTo results in "The Saml2Response didn't pass validation" in a farm setup #98
- Kentor.AuthServices/Internal/PendingAuthnRequests.cs