### PR TITLE
SAML LogoutRequest added

### DIFF
--- a/Kentor.AuthServices.HttpModule/HttpRequestBaseExtensions.cs
+++ b/Kentor.AuthServices.HttpModule/HttpRequestBaseExtensions.cs
@@ -37,6 +37,7 @@ namespace Kentor.AuthServices.HttpModule
                 requestBase.ApplicationPath,
                 requestBase.Form.Cast<string>().Select((de, i) =>
                     new KeyValuePair<string, string[]>(de, ((string)requestBase.Form[i]).Split(','))),
+                HttpUtility.ParseQueryString(requestBase.Url.Query),
                 nameIdentifier);
         }
     }

--- a/Kentor.AuthServices.HttpModule/HttpRequestBaseExtensions.cs
+++ b/Kentor.AuthServices.HttpModule/HttpRequestBaseExtensions.cs
@@ -2,8 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Security.Claims;
 using System.Web;
 
 namespace Kentor.AuthServices.HttpModule
@@ -25,12 +24,20 @@ namespace Kentor.AuthServices.HttpModule
                 throw new ArgumentNullException("requestBase");
             }
 
+            Claim nameIdentifier = null;
+            var claimsIdentity = System.Web.HttpContext.Current.User.Identity as ClaimsIdentity;
+            if (claimsIdentity != null)
+            {
+                nameIdentifier = claimsIdentity.Claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier);
+            }
+
             return new HttpRequestData(
                 requestBase.HttpMethod,
                 requestBase.Url,
                 requestBase.ApplicationPath,
                 requestBase.Form.Cast<string>().Select((de, i) =>
-                    new KeyValuePair<string, string[]>(de, ((string)requestBase.Form[i]).Split(','))));
+                    new KeyValuePair<string, string[]>(de, ((string)requestBase.Form[i]).Split(','))),
+                nameIdentifier);
         }
     }
 }

--- a/Kentor.AuthServices.Mvc/AuthServicesController.cs
+++ b/Kentor.AuthServices.Mvc/AuthServicesController.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Net;
-using System.Web.Mvc;
-using System.IdentityModel.Services;
+﻿using Kentor.AuthServices.Configuration;
 using Kentor.AuthServices.HttpModule;
-using Kentor.AuthServices.Configuration;
 using Kentor.AuthServices.WebSso;
 using System.Diagnostics.CodeAnalysis;
+using System.IdentityModel.Services;
+using System.Linq;
+using System.Security.Claims;
+using System.Web.Mvc;
 
 namespace Kentor.AuthServices.Mvc
 {
@@ -21,10 +21,11 @@ namespace Kentor.AuthServices.Mvc
         /// The options used by the controller. By default read from config, 
         /// but can be set.
         /// </summary>
-        public static IOptions Options {
+        public static IOptions Options
+        {
             get
             {
-                if(options == null)
+                if (options == null)
                 {
                     options = Configuration.Options.FromConfiguration;
                 }
@@ -76,6 +77,23 @@ namespace Kentor.AuthServices.Mvc
         {
             FederatedAuthentication.SessionAuthenticationModule.SignOut();
             return Redirect(Url.Content("~/"));
+        }
+
+        [HttpGet]
+        public ActionResult LogOff()
+        {
+            var result = CommandFactory.GetCommand(CommandFactory.SingleLogoutCommandName).Run(
+                Request.ToHttpRequestData(),
+                Options)
+                .ToActionResult();
+            return result;
+        }
+
+        [HttpPost]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "samlResponse", Justification = "TODO: verify the samlResponse")]
+        public ActionResult LogOff(string samlResponse)
+        {
+            return RedirectToAction("SignOut");
         }
 
         /// <summary>

--- a/Kentor.AuthServices/Configuration/CertificateElement.cs
+++ b/Kentor.AuthServices/Configuration/CertificateElement.cs
@@ -3,9 +3,7 @@ using System;
 using System.Configuration;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
 using System.Security.Cryptography.X509Certificates;
-using System.Web;
 
 namespace Kentor.AuthServices.Configuration
 {
@@ -43,6 +41,22 @@ namespace Kentor.AuthServices.Configuration
             internal set
             {
                 base["fileName"] = value;
+            }
+        }
+
+        /// <summary>
+        /// Password for the certificate.
+        /// </summary>
+        [ConfigurationProperty("certificatePassword")]
+        public string CertificatePassword
+        {
+            get
+            {
+                return (string)base["certificatePassword"];
+            }
+            internal set
+            {
+                base["certificatePassword"] = value;
             }
         }
 
@@ -109,7 +123,13 @@ namespace Kentor.AuthServices.Configuration
             {
                 string fileName = FileName;
                 fileName = PathHelper.MapPath(fileName);
-                
+
+                // If a certificatePassword is provided, use it to access the certificate
+                if (!string.IsNullOrEmpty(CertificatePassword))
+                {
+                    return new X509Certificate2(fileName, CertificatePassword);
+                }
+
                 return new X509Certificate2(fileName);
             }
             else

--- a/Kentor.AuthServices/Configuration/IdentityProviderElement.cs
+++ b/Kentor.AuthServices/Configuration/IdentityProviderElement.cs
@@ -24,7 +24,7 @@ namespace Kentor.AuthServices.Configuration
         {
             return isReadOnly;
         }
-                
+
         /// <summary>
         /// EntityId as presented by the idp. Used as key to configuration.
         /// </summary>
@@ -42,7 +42,7 @@ namespace Kentor.AuthServices.Configuration
         }
 
         /// <summary>
-        /// Destination url to send requests to.
+        /// Destination url to send authentication requests to.
         /// </summary>
         [ConfigurationProperty("destinationUrl")]
         public Uri DestinationUrl
@@ -54,6 +54,22 @@ namespace Kentor.AuthServices.Configuration
             internal set
             {
                 base["destinationUrl"] = value;
+            }
+        }
+
+        /// <summary>
+        /// Destination url to send logout requests to.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "Logout"), ConfigurationProperty("singleLogoutUrl")]
+        public Uri SingleLogoutUrl
+        {
+            get
+            {
+                return (Uri)base["singleLogoutUrl"];
+            }
+            internal set
+            {
+                base["singleLogoutUrl"] = value;
             }
         }
 
@@ -96,7 +112,7 @@ namespace Kentor.AuthServices.Configuration
         /// Even though AllowUnsolicitedAuthnResponse is true the InResponseTo must be valid if existing.
         /// </summary>
         [ConfigurationProperty("allowUnsolicitedAuthnResponse", IsRequired = true)]
-        public bool AllowUnsolicitedAuthnResponse 
+        public bool AllowUnsolicitedAuthnResponse
         {
             get
             {

--- a/Kentor.AuthServices/Kentor.AuthServices.csproj
+++ b/Kentor.AuthServices/Kentor.AuthServices.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Internal\PathHelper.cs" />
     <Compile Include="Internal\QueryStringHelper.cs" />
     <Compile Include="Metadata\KeyInfoSerializer.cs" />
+    <Compile Include="Saml2P\Saml2LogoutRequest.cs" />
     <Compile Include="Saml2ResponseFailedValidationException.cs" />
     <Compile Include="WebSso\AcsCommand.cs" />
     <Compile Include="Metadata\AttributeConsumingService.cs" />
@@ -127,6 +128,7 @@
     <Compile Include="WebSso\SignInCommand.cs" />
     <Compile Include="Internal\StatusCodeHelper.cs" />
     <Compile Include="Internal\StringHelpers.cs" />
+    <Compile Include="WebSso\SingleLogoutCommand.cs" />
     <Compile Include="XmlDocumentExtensions.cs" />
     <Compile Include="Metadata\XmlFilteringReader.cs" />
     <Compile Include="Internal\XmlHelpers.cs" />

--- a/Kentor.AuthServices/SAML2P/Saml2LogoutRequest.cs
+++ b/Kentor.AuthServices/SAML2P/Saml2LogoutRequest.cs
@@ -1,0 +1,108 @@
+﻿using System.Security.Cryptography.X509Certificates;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace Kentor.AuthServices.Saml2P
+{
+    /// <summary>
+    /// A logout request corresponding to section 3.7.1 in SAML Core specification.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "Logout", Justification = "The saml name is LogoutRequest")]
+    public class Saml2LogoutRequest : Saml2RequestBase
+    {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        public Saml2LogoutRequest()
+        {
+
+        }
+
+        /// <summary>
+        /// The SAML2 logout request name
+        /// </summary>
+        protected override string LocalName
+        {
+            get { return "LogoutRequest"; }
+        }
+
+        /// <summary>
+        /// The certificate to sign the LogoutRequest with.
+        /// </summary>
+        public X509Certificate2 SigningCertificate { get; set; }
+
+        /// <summary>
+        /// The value of the nameidentifier claim.
+        /// </summary>
+        public string NameIdentifierValue { get; set; }
+
+        /// <summary>
+        ///  The format in which the nameidentifier is provided.
+        /// </summary>
+        public string NameIdentifierFormat { get; set; }
+
+        /// <summary>
+        /// Serializes the request to a Xml message.
+        /// </summary>
+        /// <returns>XElement</returns>
+        public XElement ToXElement()
+        {
+            var x = new XElement(Saml2Namespaces.Saml2P + LocalName);
+
+            x.Add(base.ToXNodes());
+
+            var nameIdentifier = new XElement(Saml2Namespaces.Saml2 + "NameID", NameIdentifierValue);
+            if (!string.IsNullOrEmpty(NameIdentifierFormat))
+            {
+                nameIdentifier.Add(new XAttribute("Format", NameIdentifierFormat));
+            }
+            x.Add(nameIdentifier);
+
+            return x;
+        }
+
+        /// <summary>
+        /// Serializes the message into wellformed Xml.
+        /// </summary>
+        /// <returns>string containing the Xml data.</returns>
+        public override string ToXml()
+        {
+            string xml = ToXElement().ToString();
+
+            if (SigningCertificate != null && SigningCertificate.HasPrivateKey)
+            {
+                var xmlDoc = new XmlDocument { PreserveWhitespace = false };
+                xmlDoc.LoadXml(xml);
+                xmlDoc.Sign(SigningCertificate);
+                xml = xmlDoc.OuterXml;
+            }
+
+            return xml;
+        }
+
+        /// <summary>
+        /// Read the supplied Xml and parse it into a authenticationrequest.
+        /// </summary>
+        /// <param name="xml">xml data.</param>
+        /// <returns>Saml2Request</returns>
+        /// <exception cref="XmlException">On xml errors or unexpected xml structure.</exception>
+        public static Saml2LogoutRequest Read(string xml)
+        {
+            if (xml == null)
+            {
+                return null;
+            }
+            var x = new XmlDocument();
+            x.PreserveWhitespace = true;
+            x.LoadXml(xml);
+
+            return new Saml2LogoutRequest(x);
+        }
+
+        private Saml2LogoutRequest(XmlDocument xml)
+        {
+            ReadBaseProperties(xml);
+        }
+
+    }
+}

--- a/Kentor.AuthServices/WebSSO/CommandFactory.cs
+++ b/Kentor.AuthServices/WebSSO/CommandFactory.cs
@@ -1,9 +1,5 @@
-﻿using Kentor.AuthServices.WebSso;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Kentor.AuthServices.WebSso
 {
@@ -25,6 +21,12 @@ namespace Kentor.AuthServices.WebSso
         public const string SignInCommandName = "SignIn";
 
         /// <summary>
+        /// The name of the Single Logout Command.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "Logout")]
+        public const string SingleLogoutCommandName = "SingleLogout";
+
+        /// <summary>
         /// The metadata command has no name - it is triggered at base url for
         /// AuthServices.
         /// </summary>
@@ -36,6 +38,7 @@ namespace Kentor.AuthServices.WebSso
             { SignInCommandName, new SignInCommand() },
             { AcsCommandName, new AcsCommand() },
             { MetadataCommand, new MetadataCommand() },
+            { SingleLogoutCommandName, new SingleLogoutCommand() },
         };
 
         /// <summary>
@@ -48,12 +51,12 @@ namespace Kentor.AuthServices.WebSso
         {
             ICommand command;
 
-            if(commandName ==  null)
+            if (commandName == null)
             {
                 throw new ArgumentNullException("commandName");
             }
 
-            if(commandName.StartsWith("/", StringComparison.OrdinalIgnoreCase))
+            if (commandName.StartsWith("/", StringComparison.OrdinalIgnoreCase))
             {
                 commandName = commandName.Substring(1);
             }

--- a/Kentor.AuthServices/WebSSO/HttpRequestData.cs
+++ b/Kentor.AuthServices/WebSSO/HttpRequestData.cs
@@ -1,13 +1,9 @@
 ﻿using Kentor.AuthServices.Internal;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Web;
+using System.Security.Claims;
 
 namespace Kentor.AuthServices.WebSso
 {
@@ -24,27 +20,31 @@ namespace Kentor.AuthServices.WebSso
         /// <param name="url">Full url requested</param>
         /// <param name="formData">Form data, if present (only for POST requests)</param>
         /// <param name="applicationPath">Path to the application root</param>
+        /// <param name="nameIdentifier">The claim that contains the nameIdentifier of the logged in user</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
         public HttpRequestData(
             string httpMethod,
             Uri url,
             string applicationPath,
-            IEnumerable<KeyValuePair<string, string[]>> formData)
+            IEnumerable<KeyValuePair<string, string[]>> formData,
+            Claim nameIdentifier = null)
         {
-            Init(httpMethod, url, applicationPath, formData);
+            Init(httpMethod, url, applicationPath, formData, nameIdentifier);
         }
 
         // Used by tests.
         internal HttpRequestData(string httpMethod, Uri url)
         {
-            Init(httpMethod, url, "/", null);
+            Init(httpMethod, url, "/", null, null);
         }
 
         private void Init(
             string httpMethod,
             Uri url,
             string applicationPath,
-            IEnumerable<KeyValuePair<string, string[]>> formData)
+            IEnumerable<KeyValuePair<string, string[]>> formData,
+            Claim nameIdentifier)
         {
             HttpMethod = httpMethod;
             Url = url;
@@ -53,6 +53,7 @@ namespace Kentor.AuthServices.WebSso
                 (formData ?? Enumerable.Empty<KeyValuePair<string, string[]>>())
                 .ToDictionary(kv => kv.Key, kv => kv.Value.Single()));
             QueryString = QueryStringHelper.ParseQueryString(url.Query);
+            NameIdentifier = nameIdentifier;
         }
 
         /// <summary>
@@ -80,5 +81,10 @@ namespace Kentor.AuthServices.WebSso
         /// that the application is installed in, e.g. http://hosting.example.com/myapp/
         /// </summary>
         public Uri ApplicationUrl { get; private set; }
+
+        /// <summary>
+        /// The Claim that contains the nameidentifier of the user that is currently logged in
+        /// </summary>
+        public Claim NameIdentifier { get; private set; }
     }
 }

--- a/Kentor.AuthServices/WebSSO/HttpRequestData.cs
+++ b/Kentor.AuthServices/WebSSO/HttpRequestData.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Security.Claims;
 
@@ -18,8 +19,9 @@ namespace Kentor.AuthServices.WebSso
         /// </summary>
         /// <param name="httpMethod">Http method of the request</param>
         /// <param name="url">Full url requested</param>
-        /// <param name="formData">Form data, if present (only for POST requests)</param>
         /// <param name="applicationPath">Path to the application root</param>
+        /// <param name="formData">Form data, if present (only for POST requests)</param>
+        /// <param name="queryString">The query string parameters of the request</param>
         /// <param name="nameIdentifier">The claim that contains the nameIdentifier of the logged in user</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
@@ -28,15 +30,16 @@ namespace Kentor.AuthServices.WebSso
             Uri url,
             string applicationPath,
             IEnumerable<KeyValuePair<string, string[]>> formData,
+            NameValueCollection queryString = null,
             Claim nameIdentifier = null)
         {
-            Init(httpMethod, url, applicationPath, formData, nameIdentifier);
+            Init(httpMethod, url, applicationPath, formData, queryString, nameIdentifier);
         }
 
         // Used by tests.
         internal HttpRequestData(string httpMethod, Uri url)
         {
-            Init(httpMethod, url, "/", null, null);
+            Init(httpMethod, url, "/", null, null, null);
         }
 
         private void Init(
@@ -44,6 +47,7 @@ namespace Kentor.AuthServices.WebSso
             Uri url,
             string applicationPath,
             IEnumerable<KeyValuePair<string, string[]>> formData,
+            NameValueCollection queryString,
             Claim nameIdentifier)
         {
             HttpMethod = httpMethod;
@@ -52,7 +56,7 @@ namespace Kentor.AuthServices.WebSso
             Form = new ReadOnlyDictionary<string, string>(
                 (formData ?? Enumerable.Empty<KeyValuePair<string, string[]>>())
                 .ToDictionary(kv => kv.Key, kv => kv.Value.Single()));
-            QueryString = QueryStringHelper.ParseQueryString(url.Query);
+            QueryString = queryString ?? new NameValueCollection();
             NameIdentifier = nameIdentifier;
         }
 
@@ -74,7 +78,7 @@ namespace Kentor.AuthServices.WebSso
         /// <summary>
         /// The query string parameters of the request.
         /// </summary>
-        public ILookup<String, String> QueryString { get; private set; }
+        public NameValueCollection QueryString { get; private set; }
 
         /// <summary>
         /// The root Url of the application. This includes the virtual directory

--- a/Kentor.AuthServices/WebSSO/Saml2RedirectBinding.cs
+++ b/Kentor.AuthServices/WebSSO/Saml2RedirectBinding.cs
@@ -45,7 +45,7 @@ namespace Kentor.AuthServices.WebSso
                 throw new ArgumentNullException("request");
             }
 
-            var payload = Convert.FromBase64String(request.QueryString["SAMLRequest"].First());
+            var payload = Convert.FromBase64String(request.QueryString["SAMLRequest"]);
             using (var compressed = new MemoryStream(payload))
             {
                 using (var decompressedStream = new DeflateStream(compressed, CompressionMode.Decompress, true))

--- a/Kentor.AuthServices/WebSSO/SignInCommand.cs
+++ b/Kentor.AuthServices/WebSSO/SignInCommand.cs
@@ -27,8 +27,8 @@ namespace Kentor.AuthServices.WebSso
             }
 
             return CreateResult(
-                new EntityId(request.QueryString["idp"].FirstOrDefault()),
-                request.QueryString["ReturnUrl"].FirstOrDefault(),
+                new EntityId(request.QueryString["idp"]),
+                request.QueryString["ReturnUrl"],
                 request,
                 options);
         }

--- a/Kentor.AuthServices/WebSSO/SingleLogoutCommand.cs
+++ b/Kentor.AuthServices/WebSSO/SingleLogoutCommand.cs
@@ -23,8 +23,8 @@ namespace Kentor.AuthServices.WebSso
             }
 
             return CreateResult(
-                new EntityId(request.QueryString["idp"].FirstOrDefault()),
-                request.QueryString["ReturnUrl"].FirstOrDefault(),
+                new EntityId(request.QueryString["idp"]),
+                request.QueryString["ReturnUrl"],
                 request,
                 options);
         }

--- a/Kentor.AuthServices/WebSSO/SingleLogoutCommand.cs
+++ b/Kentor.AuthServices/WebSSO/SingleLogoutCommand.cs
@@ -1,0 +1,104 @@
+﻿using Kentor.AuthServices.Configuration;
+using System;
+using System.Globalization;
+using System.IdentityModel.Metadata;
+using System.Linq;
+using System.Net;
+using System.Security.Claims;
+
+namespace Kentor.AuthServices.WebSso
+{
+    class SingleLogoutCommand : ICommand
+    {
+        public CommandResult Run(HttpRequestData request, IOptions options)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException("request");
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException("options");
+            }
+
+            return CreateResult(
+                new EntityId(request.QueryString["idp"].FirstOrDefault()),
+                request.QueryString["ReturnUrl"].FirstOrDefault(),
+                request,
+                options);
+        }
+
+        public static CommandResult CreateResult(
+            EntityId idpEntityId,
+            string returnPath,
+            HttpRequestData request,
+            IOptions options,
+            object relayData = null)
+        {
+            var urls = new AuthServicesUrls(request, options.SPOptions);
+
+            IdentityProvider idp;
+            if (idpEntityId == null || idpEntityId.Id == null)
+            {
+                if (options.SPOptions.DiscoveryServiceUrl != null)
+                {
+                    return RedirectToDiscoveryService(returnPath, options.SPOptions, urls);
+                }
+
+                idp = options.IdentityProviders.Default;
+            }
+            else
+            {
+                if (!options.IdentityProviders.TryGetValue(idpEntityId, out idp))
+                {
+                    throw new InvalidOperationException("Unknown idp");
+                }
+            }
+
+            Uri returnUrl = null;
+            if (!string.IsNullOrEmpty(returnPath))
+            {
+                Uri.TryCreate(request.Url, returnPath, out returnUrl);
+            }
+
+            string nameIdentifierValue = string.Empty;
+            string nameIdentifierFormat = string.Empty;
+            if (request.NameIdentifier != null)
+            {
+                nameIdentifierValue = request.NameIdentifier.Value;
+                nameIdentifierFormat = request.NameIdentifier.Properties[ClaimProperties.SamlNameIdentifierFormat];
+            }
+
+            var logoutRequest = idp.CreateLogoutRequest(returnUrl, nameIdentifierValue, nameIdentifierFormat, relayData);
+
+            return idp.Bind(logoutRequest);
+        }
+
+        private static CommandResult RedirectToDiscoveryService(
+            string returnPath,
+            ISPOptions spOptions,
+            AuthServicesUrls authServicesUrls)
+        {
+            string returnUrl = authServicesUrls.SignInUrl.OriginalString;
+
+            if (!string.IsNullOrEmpty(returnPath))
+            {
+                returnUrl += "?ReturnUrl=" + Uri.EscapeDataString(returnPath);
+            }
+
+            var redirectLocation = string.Format(
+                CultureInfo.InvariantCulture,
+                "{0}?entityID={1}&return={2}&returnIDParam=idp",
+                spOptions.DiscoveryServiceUrl,
+                Uri.EscapeDataString(spOptions.EntityId.Id),
+                Uri.EscapeDataString(returnUrl));
+
+            return new CommandResult()
+            {
+                HttpStatusCode = HttpStatusCode.SeeOther,
+                Location = new Uri(redirectLocation)
+            };
+        }
+    }
+}

--- a/SampleMvcApplication/Views/Home/Index.cshtml
+++ b/SampleMvcApplication/Views/Home/Index.cshtml
@@ -29,6 +29,9 @@ else
     <p>
         You are signed in. <a href="@Url.Action("../AuthServices/SignOut")">Sign out</a>.
     </p>
+    <p>
+        <a href="@Url.Content("~/AuthServices/LogOff")">Click here to log off using saml logout</a>
+    </p>
     <table>
         <thead>
             <tr>
@@ -44,7 +47,65 @@ else
                     <td>@c.Type</td>
                     <td>@c.Value</td>
                     <td>@c.Issuer</td>
-                </tr>                
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+<p>
+    <a href="@Url.Content("~/AuthServices/")">Service Provider Metadata.</a>
+</p>
+@{
+    ViewBag.Title = "Home Page";
+}
+
+
+<h1>Sample Saml2 MVC Authentication Application</h1>
+<p>
+    This is a sample MVC application for Saml2 authentication using the MVC Controller configuration.
+</p>
+
+@if (!User.Identity.IsAuthenticated)
+{
+    <p>
+        You are currently not signed in.
+    </p>
+    <p>
+        <a href="@Url.Content("~/AuthServices/SignIn")">Sign in</a> - default IDP
+        @foreach (var idp in Kentor.AuthServices.Configuration.KentorAuthServicesSection.Current.IdentityProviders)
+        {
+            var entityID = idp.EntityId;
+            var destinationUrl = idp.DestinationUrl;
+            <br />
+            <a href="@Url.Content("~/AuthServices/SignIn?idp=" + HttpUtility.UrlEncode(entityID))">Sign in</a>@: - @entityID - @destinationUrl
+        }
+    </p>
+}
+else
+{
+    <p>
+        You are signed in. <a href="@Url.Action("../AuthServices/SignOut")">Sign out</a>.
+    </p>
+    <p>
+        <a href="@Url.Content("~/AuthServices/LogOff")">Click here to log off using saml logout</a>
+    </p>
+    <table>
+        <thead>
+            <tr>
+                <th>Claim Type</th>
+                <th>Claim Value</th>
+                <th>Issuer</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var c in System.Security.Claims.ClaimsPrincipal.Current.Claims)
+            {
+                <tr>
+                    <td>@c.Type</td>
+                    <td>@c.Value</td>
+                    <td>@c.Issuer</td>
+                </tr>
             }
         </tbody>
     </table>

--- a/SampleMvcApplication/Views/Home/Secure.cshtml
+++ b/SampleMvcApplication/Views/Home/Secure.cshtml
@@ -8,8 +8,11 @@
 <p>This is a secure page that only works when logged in.</p>
 <p>Claims:</p>
 <ul>
-    @foreach(var claim in Model)
+    @foreach (var claim in Model)
     {
         <li>@claim.Type - @claim.Value</li>
     }
 </ul>
+<p>
+    <a href="@Url.Content("~/AuthServices/LogOff")">Click here to log off using saml logout</a>
+</p>


### PR DESCRIPTION
Hello Anders,

One of my customers was using Kentor AuthServices, but now they required the use of SAML Logout. I added support for a SAML LogoutRequest, which should always be signed.

Some remarks:
- In the config I had to add a property to configure the Url where the LogoutRequest should be posted to.
- In the Mvc project in the AuthServicesController I added methods with the name LogOff. I wasn't entirely sure if I should create separate methods for this or reuse the existing SignOut. Right now, there is a redirect to SignOut after the Logout-cycle is complete.
- Because we need to know which user to sign out, we need to get his name somehow. There are several places where I could implement this, but in the end I decided to go for the HttpRequestBaseExtensions and get the NameIdentifier there from the ClaimsIdentity.

Kind regards,
Roger Frehen