### PR TITLE
Add test cases for signed assertions with KeyInfo

### DIFF
--- a/Kentor.AuthServices.TestHelpers/SignedXmlHelper.cs
+++ b/Kentor.AuthServices.TestHelpers/SignedXmlHelper.cs
@@ -19,12 +19,12 @@ namespace Kentor.AuthServices.TestHelpers
                 (new X509SecurityToken(TestCert))
                 .CreateKeyIdentifierClause<X509RawDataKeyIdentifierClause>()));
 
-        public static string SignXml(string xml)
+        public static string SignXml(string xml, bool includeKeyInfo = false, bool preserveWhitespace = true)
         {
-            var xmlDoc = new XmlDocument { PreserveWhitespace = true };
+            var xmlDoc = new XmlDocument { PreserveWhitespace = preserveWhitespace };
             xmlDoc.LoadXml(xml);
 
-            xmlDoc.Sign(TestCert);
+            xmlDoc.Sign(TestCert, includeKeyInfo);
 
             return xmlDoc.OuterXml;
         }

--- a/Kentor.AuthServices.Tests/Saml2P/Saml2ResponseTests.cs
+++ b/Kentor.AuthServices.Tests/Saml2P/Saml2ResponseTests.cs
@@ -212,6 +212,39 @@ namespace Kentor.AuthServices.Tests.Saml2P
         }
 
         [TestMethod]
+        public void Saml2Response_GetClaims_CorrectSignedSingleAssertion_WithKeyInfo_InResponseMessage()
+        {
+            var response =
+            @"<saml2p:Response xmlns:saml2p=""urn:oasis:names:tc:SAML:2.0:protocol""
+            xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+            ID = ""Saml2Response_GetClaims_CorrectSignedSingleAssertion_WithKeyInfo_InResponseMessage"" Version=""2.0"" IssueInstant=""2013-01-01T00:00:00Z"">
+                <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                <saml2p:Status>
+                    <saml2p:StatusCode Value=""urn:oasis:names:tc:SAML:2.0:status:Success"" />
+                </saml2p:Status>
+                {0}
+            </saml2p:Response>";
+
+            var assertion =
+            @"<saml2:Assertion xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+                Version=""2.0"" ID=""_{0}""
+                IssueInstant=""2013-09-25T00:00:00Z"">
+                    <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                    <saml2:Subject>
+                        <saml2:NameID>SomeUser</saml2:NameID>
+                        <saml2:SubjectConfirmation Method=""urn:oasis:names:tc:SAML:2.0:cm:bearer"" />
+                    </saml2:Subject>
+                    <saml2:Conditions NotOnOrAfter=""2100-01-01T00:00:00Z"" />
+                </saml2:Assertion>";
+
+            var signedAssertion = SignedXmlHelper.SignXml(string.Format(assertion, Guid.NewGuid()), true, false);
+            var signedResponse = string.Format(response, signedAssertion);
+
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            a.ShouldNotThrow();
+        }
+
+        [TestMethod]
         [Ignore]
         public void Saml2Response_GetClaims_CorrectSignedMultipleAssertionInResponseMessage()
         {
@@ -252,6 +285,51 @@ namespace Kentor.AuthServices.Tests.Saml2P
 
             var signedAssertion1 = SignedXmlHelper.SignXml(assertion1);
             var signedAssertion2 = SignedXmlHelper.SignXml(assertion2);
+            var signedResponse = string.Format(response, signedAssertion1, signedAssertion2);
+
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            a.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        public void Saml2Response_GetClaims_CorrectSignedMultipleAssertion_WithKeyInfo_InResponseMessage()
+        {
+            var response =
+            @"<saml2p:Response xmlns:saml2p=""urn:oasis:names:tc:SAML:2.0:protocol""
+            xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+            ID = ""Saml2Response_GetClaims_TrueOnCorrectSignedMultipleAssertionInResponseMessage"" Version=""2.0"" IssueInstant=""2013-01-01T00:00:00Z"">
+                <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                <saml2p:Status>
+                    <saml2p:StatusCode Value=""urn:oasis:names:tc:SAML:2.0:status:Success"" />
+                </saml2p:Status>
+                {0}
+                {1}
+            </saml2p:Response>";
+
+            var assertion1 = @"<saml2:Assertion xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+                Version=""2.0"" ID=""_{0}""
+                IssueInstant=""2013-09-25T00:00:00Z"">
+                    <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                    <saml2:Subject>
+                        <saml2:NameID>SomeUser</saml2:NameID>
+                        <saml2:SubjectConfirmation Method=""urn:oasis:names:tc:SAML:2.0:cm:bearer"" />
+                    </saml2:Subject>
+                    <saml2:Conditions NotOnOrAfter=""2100-01-01T00:00:00Z"" />
+                </saml2:Assertion>";
+
+            var assertion2 = @"<saml2:Assertion xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+                Version=""2.0"" ID=""_{0}""
+                IssueInstant=""2013-09-25T00:00:00Z"">
+                    <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                    <saml2:Subject>
+                        <saml2:NameID>SomeUser2</saml2:NameID>
+                        <saml2:SubjectConfirmation Method=""urn:oasis:names:tc:SAML:2.0:cm:bearer"" />
+                    </saml2:Subject>
+                    <saml2:Conditions NotOnOrAfter=""2100-01-01T00:00:00Z"" />
+                </saml2:Assertion>";
+
+            var signedAssertion1 = SignedXmlHelper.SignXml(string.Format(assertion1, Guid.NewGuid()), true, false);
+            var signedAssertion2 = SignedXmlHelper.SignXml(string.Format(assertion2, Guid.NewGuid()), true, false);
             var signedResponse = string.Format(response, signedAssertion1, signedAssertion2);
 
             Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);

--- a/Kentor.AuthServices/XmlDocumentExtensions.cs
+++ b/Kentor.AuthServices/XmlDocumentExtensions.cs
@@ -20,6 +20,19 @@ namespace Kentor.AuthServices
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1059:MembersShouldNotExposeCertainConcreteTypes", MessageId = "System.Xml.XmlNode")]
         public static void Sign(this XmlDocument xmlDocument, X509Certificate2 cert)
         {
+            Sign(xmlDocument, cert, false);
+        }
+
+        /// <summary>
+        /// Sign an xml document with the supplied cert.
+        /// </summary>
+        /// <param name="xmlDocument">XmlDocument to be signed. The signature is
+        /// added as a node in the document, right after the Issuer node.</param>
+        /// <param name="cert">Certificate to use when signing.</param>
+        /// <param name="includeKeyInfo">Include public key in signed output.</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1059:MembersShouldNotExposeCertainConcreteTypes", MessageId = "System.Xml.XmlNode")]
+        public static void Sign(this XmlDocument xmlDocument, X509Certificate2 cert, bool includeKeyInfo)
+        {
             if (xmlDocument == null)
             {
                 throw new ArgumentNullException("xmlDocument");
@@ -47,6 +60,13 @@ namespace Kentor.AuthServices
 
             signedXml.AddReference(reference);
             signedXml.ComputeSignature();
+
+            if (includeKeyInfo)
+            {
+                var keyInfo = new KeyInfo();
+                keyInfo.AddClause(new KeyInfoX509Data(cert));
+                signedXml.KeyInfo = keyInfo;
+            }
 
             xmlDocument.DocumentElement.InsertAfter(
                 xmlDocument.ImportNode(signedXml.GetXml(), true),


### PR DESCRIPTION
The failing test cases for #191 are when the signed assertion does **not** have `<KeyInfo>` node and the WIF token handler requires an IssuerTokenResolver to look up the key. Just to be sure we cover all scenarios, added these test cases for when the signed assertion **does** have `<KeyInfo>`.

In order to do this, had to add some optional parameters to SignedXmlHelper and XmlDocumentExtensions so we have the option of generating the assertions with the extra node.