### PR TITLE
Implement constructor for supplying full Urls to AuthServicesUrls

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -8,3 +8,4 @@ Lisa Bylund
 Sebastian Allard
 Jozef Raschmann
 Tor-Björn Holmström
+Stephen Patches

--- a/Kentor.AuthServices.Tests/WebSSO/AuthServicesUrlsTests.cs
+++ b/Kentor.AuthServices.Tests/WebSSO/AuthServicesUrlsTests.cs
@@ -38,7 +38,7 @@ namespace Kentor.AuthServices.Tests.WebSso
         [TestMethod]
         public void AuthServicesUrls_Ctor_NullCheckModulePath()
         {
-            Action a = () => new AuthServicesUrls(new Uri("http://localhost"), null);
+            Action a = () => new AuthServicesUrls(new Uri("http://localhost"), (string)null);
 
             a.ShouldThrow<ArgumentNullException>("modulePath");
         }
@@ -76,6 +76,36 @@ namespace Kentor.AuthServices.Tests.WebSso
             Action a = () => new AuthServicesUrls(appUrl, modulePath);
 
             a.ShouldThrow<ArgumentException>("modulePath should start with /.");
+        }
+
+        [TestMethod]
+        public void AuthServiecsUrls_Ctor_AcceptsFullUrls()
+        {
+            var acsUrl = new Uri( "http://localhost:73/MyApp/MyAcs" );
+            var signinUrl = new Uri( "http://localhost:73/MyApp/MySignin" );
+
+            var subject = new AuthServicesUrls( acsUrl, signinUrl );
+
+            subject.AssertionConsumerServiceUrl.ToString().Should().Be(acsUrl.ToString());
+            subject.SignInUrl.ToString().Should().Be(signinUrl.ToString());
+        }
+
+        [TestMethod]
+        public void AuthServicesUrls_Ctor_AllowsNullAcs()
+        {
+            // AssertionConsumerServiceURL is optional in the SAML spec 
+            var subject = new AuthServicesUrls(null, new Uri("http://localhost/signin"));
+
+            subject.AssertionConsumerServiceUrl.Should().Be(null);
+            subject.SignInUrl.ToString().Should().Be("http://localhost/signin");
+        }
+
+        [TestMethod]
+        public void AuthServicesUrls_Ctor_NullCheckSignin()
+        {
+            Action a = () => new AuthServicesUrls(new Uri("http://localhost/signin"), (Uri)null);
+
+            a.ShouldThrow<ArgumentNullException>("signInUrl");
         }
     }
 }

--- a/Kentor.AuthServices.Tests/WebSSO/AuthServicesUrlsTests.cs
+++ b/Kentor.AuthServices.Tests/WebSSO/AuthServicesUrlsTests.cs
@@ -38,7 +38,7 @@ namespace Kentor.AuthServices.Tests.WebSso
         [TestMethod]
         public void AuthServicesUrls_Ctor_NullCheckModulePath()
         {
-            Action a = () => new AuthServicesUrls(new Uri("http://localhost"), (string)null);
+            Action a = () => new AuthServicesUrls(new Uri("http://localhost"), modulePath: null);
 
             a.ShouldThrow<ArgumentNullException>("modulePath");
         }
@@ -103,7 +103,7 @@ namespace Kentor.AuthServices.Tests.WebSso
         [TestMethod]
         public void AuthServicesUrls_Ctor_NullCheckSignin()
         {
-            Action a = () => new AuthServicesUrls(new Uri("http://localhost/signin"), (Uri)null);
+            Action a = () => new AuthServicesUrls(new Uri("http://localhost/signin"), signInUrl: null);
 
             a.ShouldThrow<ArgumentNullException>("signInUrl");
         }

--- a/Kentor.AuthServices/WebSSO/AuthServicesUrls.cs
+++ b/Kentor.AuthServices/WebSSO/AuthServicesUrls.cs
@@ -39,6 +39,7 @@ namespace Kentor.AuthServices.WebSso
         /// </summary>
         /// <param name="applicationUrl">The full Url to the root of the application.</param>
         /// <param name="modulePath">Path of module, starting with / and ending without.</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage( "Microsoft.Design", "CA1057:StringUriOverloadsCallSystemUriOverloads" )]
         public AuthServicesUrls(Uri applicationUrl, string modulePath)
         {
             if (applicationUrl == null)
@@ -52,6 +53,23 @@ namespace Kentor.AuthServices.WebSso
             }
 
             Init(applicationUrl, modulePath);
+        }
+
+        /// <summary>
+        /// Creates the urls for AuthServices based on the given full urls
+        /// for assertion consumer service and sign-in
+        /// </summary>
+        /// <param name="assertionConsumerServiceUrl">The full Url for the Assertion Consumer Service.</param>
+        /// <param name="signInUrl">The full Url for sign-in.</param>
+        public AuthServicesUrls(Uri assertionConsumerServiceUrl, Uri signInUrl)
+        {
+            if (signInUrl == null)
+            {
+                throw new ArgumentNullException("signInUrl");
+            }
+
+            AssertionConsumerServiceUrl = assertionConsumerServiceUrl;
+            SignInUrl = signInUrl;
         }
 
         void Init(Uri applicationUrl, string modulePath)

--- a/Kentor.AuthServices/WebSSO/AuthServicesUrls.cs
+++ b/Kentor.AuthServices/WebSSO/AuthServicesUrls.cs
@@ -39,7 +39,8 @@ namespace Kentor.AuthServices.WebSso
         /// </summary>
         /// <param name="applicationUrl">The full Url to the root of the application.</param>
         /// <param name="modulePath">Path of module, starting with / and ending without.</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage( "Microsoft.Design", "CA1057:StringUriOverloadsCallSystemUriOverloads" )]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage( "Microsoft.Design", "CA1057:StringUriOverloadsCallSystemUriOverloads"
+            , Justification = "Incorrect warning. modulePath isn't a string representation of a Uri" )]
         public AuthServicesUrls(Uri applicationUrl, string modulePath)
         {
             if (applicationUrl == null)


### PR DESCRIPTION
Fixes #211 

I'm not 100% happy with having to cast a null in some cases to disambiguate the constructors. Let me know if you see a better way.