### PR TITLE
Fix #215 - Include parsed SAMLResponse in exceptions

### DIFF
--- a/Kentor.AuthServices.Tests/WebSSO/AcsCommandTests.cs
+++ b/Kentor.AuthServices.Tests/WebSSO/AcsCommandTests.cs
@@ -96,7 +96,7 @@ namespace Kentor.AuthServices.Tests.WebSso
             string payload =
                 @"<saml2p:Response xmlns:saml2p=""urn:oasis:names:tc:SAML:2.0:protocol""
                 xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
-                ID = ""AcsCommand_Run_SuccessfulResult"" Version=""2.0"" />";
+                ID = ""AcsCommand_Run_ResponseIncludedInException"" Version=""2.0"" />";
             var encoded = Convert.ToBase64String(Encoding.UTF8.GetBytes(payload));
             var r = new HttpRequestData(
                 "POST",


### PR DESCRIPTION
Include parsed SAMLResponse in exceptions thrown from AcsCommand.Run
Fixes #215 

I put together a solution where the unpacked Saml2Response-string is added to the Exception.Data dictionary.
Please have a look at the way I "monkey patch" the payload onto the exceptions in AcsCommand:58
I prefer to add the payload to the existing exception instead of wrapping in a new exception with the old as an inner exception to preserve the original Exception type and not hide the original exception to many onion layers down.