### PR TITLE
Proposed to fix #246: Read Audience Uris from web.config/system.IdentityModel. 

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -9,3 +9,4 @@ Sebastian Allard
 Jozef Raschmann
 Tor-Björn Holmström
 Stephen Patches
+Matthew Paul

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -87,7 +87,8 @@ Root element of the config section.
 The name that this service provider will use for itself when sending
 messages. The name will end up in the `Issuer` field in outcoing authnRequests.
 
-The `entityId` should typically be the URL where the metadata is presented. E.g.
+The SAML standard requires the `entityId` to be an absolut URI. Typically it should
+be the URL where the metadata is presented. E.g.
 `http://sp.example.com/AuthServices/`.
 
 ####`returnUrl` Attribute


### PR DESCRIPTION
Update to constructor on Saml2PSecurityTokenHandler to read audience restrictions from system.identitymodel and fall back to a restriction based on entityid.id if none have been applied. Covered by two tests in Saml2PSecurityTokenHandlerTests:

Saml2PSecurityTokenHandler_ShouldHaveDefaultAudienceRestrictionOfEntityId
Saml2PSecurityTokenHandler_ShouldReadAudienceUrisFromIdentityModelConfig