### PR TITLE
Work around base WIF exception when AuthnContextDeclRef is included

### DIFF
--- a/Kentor.AuthServices.Tests/Saml2P/Saml2ResponseTests.cs
+++ b/Kentor.AuthServices.Tests/Saml2P/Saml2ResponseTests.cs
@@ -201,6 +201,43 @@ namespace Kentor.AuthServices.Tests.Saml2P
 
         [TestMethod]
         [NotReRunnable]
+        public void Saml2Response_GetClaims_CorrectSignedResponseMessage_WithAuthnStatement()
+        {
+            var response =
+            @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            <saml2p:Response xmlns:saml2p=""urn:oasis:names:tc:SAML:2.0:protocol""
+            xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+            ID = """ + MethodBase.GetCurrentMethod().Name + @""" Version=""2.0"" IssueInstant=""2013-01-01T00:00:00Z"">
+                <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                <saml2p:Status>
+                    <saml2p:StatusCode Value=""urn:oasis:names:tc:SAML:2.0:status:Success"" />
+                </saml2p:Status>
+                <saml2:Assertion xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+                Version=""2.0"" ID=""" + MethodBase.GetCurrentMethod().Name + @"_Assertion1""
+                IssueInstant=""2013-09-25T00:00:00Z"">
+                    <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                    <saml2:Subject>
+                        <saml2:NameID>SomeUser</saml2:NameID>
+                        <saml2:SubjectConfirmation Method=""urn:oasis:names:tc:SAML:2.0:cm:bearer"" />
+                    </saml2:Subject>
+                    <saml2:Conditions NotOnOrAfter=""2100-01-01T00:00:00Z"" />
+                    <saml2:AuthnStatement AuthnInstant=""2013-09-25T00:00:00Z"" SessionIndex=""" + MethodBase.GetCurrentMethod().Name + @""" >
+                        <saml2:AuthnContext>
+                            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml2:AuthnContextClassRef>
+                            <saml2:AuthnContextDeclRef>http://custom/password/form/consumer</saml2:AuthnContextDeclRef>
+                        </saml2:AuthnContext>
+                    </saml2:AuthnStatement>
+                </saml2:Assertion>
+            </saml2p:Response>";
+
+            var signedResponse = SignedXmlHelper.SignXml(response);
+
+            Action a = () => Saml2Response.Read(signedResponse).GetClaims(Options.FromConfiguration);
+            a.ShouldNotThrow();
+        }
+
+        [TestMethod]
+        [NotReRunnable]
         public void Saml2Response_GetClaims_CorrectSignedSingleAssertionInResponseMessage()
         {
             var response =

--- a/Kentor.AuthServices/SAML2P/Saml2PSecurityTokenHandler.cs
+++ b/Kentor.AuthServices/SAML2P/Saml2PSecurityTokenHandler.cs
@@ -80,5 +80,23 @@ namespace Kentor.AuthServices.Saml2P
         {
             base.ValidateConditions(conditions, enforceAudienceRestriction);
         }
+
+        /// <summary>
+        /// Process authentication statement from SAML assertion. WIF chokes if the authentication statement 
+        /// contains a DeclarationReference, so we clear this out before calling the base method
+        /// http://referencesource.microsoft.com/#System.IdentityModel/System/IdentityModel/Tokens/Saml2SecurityTokenHandler.cs,1970
+        /// </summary>
+        /// <param name="statement">Authentication statement</param>
+        /// <param name="subject">Claim subject</param>
+        /// <param name="issuer">Assertion Issuer</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0" )]
+        protected override void ProcessAuthenticationStatement(Saml2AuthenticationStatement statement, ClaimsIdentity subject, string issuer)
+        {
+            if (statement.AuthenticationContext != null)
+            {
+                statement.AuthenticationContext.DeclarationReference = null;
+            }
+            base.ProcessAuthenticationStatement(statement, subject, issuer);
+        }
     }
 }


### PR DESCRIPTION
Today we are unable to process assertions that contain an `<AuthnContextDeclRef>` because the base WIF class actively throws exception for this:
http://referencesource.microsoft.com/#System.IdentityModel/System/IdentityModel/Tokens/Saml2SecurityTokenHandler.cs,1970

The message is: 
> System.InvalidOperationException: ID4180: A SAML2 assertion that specifies an AuthenticationContext DeclarationReference is not supported. To handle DeclarationReference, extend the Saml2SecurityTokenHandler and override ProcessAuthenticationStatement

This change simply works around the exception by clearing that property if it is present. Further work would be required to allow a user of this library to actually make decisions based on the values in that property, but this seems like an uncommon scenario.


