### PR TITLE
Fix Compilation warning "The variable 'ex' is declared but never used"

### DIFF
--- a/Kentor.AuthServices/SAML2P/Saml2Response.cs
+++ b/Kentor.AuthServices/SAML2P/Saml2Response.cs
@@ -417,7 +417,7 @@ namespace Kentor.AuthServices.Saml2P
                     throw new Saml2ResponseFailedValidationException("Signature validation failed on SAML response or contained assertion.");
                 }
             }
-            catch (CryptographicException ex)
+            catch (CryptographicException)
             {
                 if (signedXml.SignatureMethod == Options.RsaSha256Namespace && CryptoConfig.CreateFromName(signedXml.SignatureMethod) == null)
                 {


### PR DESCRIPTION
Fix Compilation warning "The variable 'ex' is declared but never used" and corresponding code analysis warning