### PR TITLE
Support for loading metadata from local xml files using file:// URI scheme

### DIFF
--- a/Kentor.AuthServices/Configuration/FederationElement.cs
+++ b/Kentor.AuthServices/Configuration/FederationElement.cs
@@ -14,7 +14,7 @@ namespace Kentor.AuthServices.Configuration
     {
         private const string metadataUrl = "metadataUrl";
         /// <summary>
-        /// Url to download metdata for the federation from.
+        /// Url to download metadata for the federation from.
         /// </summary>
         [ConfigurationProperty(metadataUrl, IsRequired = true)]
         public Uri MetadataUrl

--- a/Kentor.AuthServices/Metadata/ExtendedEntitiesDescriptor.cs
+++ b/Kentor.AuthServices/Metadata/ExtendedEntitiesDescriptor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IdentityModel.Metadata;
 using System.Linq;
 using System.Text;
@@ -12,6 +13,14 @@ namespace Kentor.AuthServices.Metadata
     /// </summary>
     public class ExtendedEntitiesDescriptor : EntitiesDescriptor, ICachedMetadata
     {
+
+        public ExtendedEntitiesDescriptor() : base() { }
+        public ExtendedEntitiesDescriptor(Collection<EntityDescriptor> entityList)
+            : base(entityList)
+        {
+
+        }
+
         /// <summary>
         /// Permitted cache duration for the metadata.
         /// </summary>

--- a/Kentor.AuthServices/Metadata/MetadataLoader.cs
+++ b/Kentor.AuthServices/Metadata/MetadataLoader.cs
@@ -89,7 +89,16 @@ namespace Kentor.AuthServices.Metadata
                 throw new ArgumentNullException("metadataUrl");
             }
 
-            return (ExtendedEntitiesDescriptor)Load(metadataUrl);
+            MetadataBase loadedMetadata = Load(metadataUrl);
+
+            if (loadedMetadata is ExtendedEntitiesDescriptor)
+                return (ExtendedEntitiesDescriptor)loadedMetadata;
+            else
+            {
+                List<EntityDescriptor> list = new List<EntityDescriptor>();
+                list.Add((ExtendedEntityDescriptor)loadedMetadata);
+                return new ExtendedEntitiesDescriptor(new System.Collections.ObjectModel.Collection<EntityDescriptor>(list));
+            }
         }
     }
 }

--- a/Kentor.AuthServices/Metadata/MetadataLoader.cs
+++ b/Kentor.AuthServices/Metadata/MetadataLoader.cs
@@ -33,6 +33,12 @@ namespace Kentor.AuthServices.Metadata
             return (ExtendedEntityDescriptor)Load(metadataUrl);
         }
 
+        /// <summary>
+        /// <para>Loads metadata XML from the specified URI</para>
+        /// <para>Supports loading from a local file URI, or remote http(s) schemes using WebClient</para>
+        /// </summary>
+        /// <param name="metadataUrl"></param>
+        /// <returns></returns>
         private static MetadataBase Load(Uri metadataUrl)
         {
             switch (metadataUrl.Scheme)

--- a/Kentor.AuthServices/Metadata/MetadataLoader.cs
+++ b/Kentor.AuthServices/Metadata/MetadataLoader.cs
@@ -35,10 +35,24 @@ namespace Kentor.AuthServices.Metadata
 
         private static MetadataBase Load(Uri metadataUrl)
         {
-            using (var client = new WebClient())
-            using (var stream = client.OpenRead(metadataUrl.ToString()))
+            switch (metadataUrl.Scheme)
             {
-                return Load(stream);
+                case "file":
+                    // load local xml metadata file
+                    using (var stream = File.OpenRead(metadataUrl.LocalPath))
+                    {
+                        return Load(stream);
+                    }
+                case "http":
+                case "https":
+                    // load http/https using the web client
+                    using (var client = new WebClient())
+                    using (var stream = client.OpenRead(metadataUrl.ToString()))
+                    {
+                        return Load(stream);
+                    }
+                default:
+                    throw new InvalidOperationException("Metadata loading is not supported for specified URI: " + metadataUrl);
             }
         }
 


### PR DESCRIPTION
Current code loads any metadata xml from a remote URI using WebClient. This will add support to loading the metadata xml file locally in certain SAML integration scenarios. For example, the metadata XML can be stored in the App_Data directory.

This might be a resolution for #201 

--------------------

InvalidCastException happening in LoadFederation() because underlying Load() returns an ExtendedEntityDescriptor, so a wrapper added that just creates a ExtendedEntitiesDescriptor with a single ExtendedEntityDescriptor inside


<!---
@huboard:{"order":274.0,"milestone_order":274,"custom_state":"blocked"}
-->
