### PR TITLE
made "Destination" and "NameIDPolicy" deserialize from original request

### DIFF
--- a/Kentor.AuthServices.Tests/Saml2P/Saml2AuthenticationRequestTests.cs
+++ b/Kentor.AuthServices.Tests/Saml2P/Saml2AuthenticationRequestTests.cs
@@ -125,6 +125,95 @@ namespace Kentor.AuthServices.Tests.Saml2P
             a.ShouldThrow<XmlException>().WithMessage("Wrong or unsupported SAML2 version");
         }
 
+
+        [TestMethod]
+        public void Saml2AuthenticationRequest_Read_Destination()
+        {
+            var xmlData = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<samlp:AuthnRequest
+  xmlns:samlp=""urn:oasis:names:tc:SAML:2.0:protocol""
+  xmlns:saml=""urn:oasis:names:tc:SAML:2.0:assertion""
+  ID=""Saml2AuthenticationRequest_Read_NoACS""
+  Version=""2.0""
+  Destination=""http://destination.example.com""
+  IssueInstant=""2004-12-05T09:21:59Z"">
+  <saml:Issuer>https://sp.example.com/SAML2</saml:Issuer>
+/>
+</samlp:AuthnRequest>
+";
+
+            var subject = Saml2AuthenticationRequest.Read(xmlData);
+
+            subject.DestinationUrl.Should().Be(new Uri("http://destination.example.com"));
+        }
+
+        [TestMethod]
+        public void Saml2AuthenticationRequest_Read_NameIDPolicy()
+        {
+            var xmlData = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<samlp:AuthnRequest
+  xmlns:samlp=""urn:oasis:names:tc:SAML:2.0:protocol""
+  xmlns:saml=""urn:oasis:names:tc:SAML:2.0:assertion""
+  ID=""Saml2AuthenticationRequest_Read_NoACS""
+  Version=""2.0""
+  Destination=""http://destination.example.com""
+  IssueInstant=""2004-12-05T09:21:59Z"">
+  <saml:Issuer>https://sp.example.com/SAML2</saml:Issuer>
+  <samlp:NameIDPolicy Format=""urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"" AllowCreate=""true""></samlp:NameIDPolicy>
+</samlp:AuthnRequest>
+";
+
+            var subject = Saml2AuthenticationRequest.Read(xmlData);
+
+            subject.NameIdPolicy.Should().NotBeNull();
+            subject.NameIdPolicy.Format.Should().Be("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress");
+            subject.NameIdPolicy.AllowCreate.Should().Be(true);
+        }
+
+        [TestMethod]
+        public void Saml2AuthenticationRequest_Read_NameIDPolicy_NullIfNotExists()
+        {
+            var xmlData = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<samlp:AuthnRequest
+  xmlns:samlp=""urn:oasis:names:tc:SAML:2.0:protocol""
+  xmlns:saml=""urn:oasis:names:tc:SAML:2.0:assertion""
+  ID=""Saml2AuthenticationRequest_Read_NoACS""
+  Version=""2.0""
+  Destination=""http://destination.example.com""
+  IssueInstant=""2004-12-05T09:21:59Z"">
+  <saml:Issuer>https://sp.example.com/SAML2</saml:Issuer>
+</samlp:AuthnRequest>
+";
+
+            var subject = Saml2AuthenticationRequest.Read(xmlData);
+
+            subject.NameIdPolicy.Should().BeNull();
+        }
+
+
+        [TestMethod]
+        public void Saml2AuthenticationRequest_Read_NameIDPolicy_AllowCreateShouldBeFalseIfUnableToParse()
+        {
+            var xmlData = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<samlp:AuthnRequest
+  xmlns:samlp=""urn:oasis:names:tc:SAML:2.0:protocol""
+  xmlns:saml=""urn:oasis:names:tc:SAML:2.0:assertion""
+  ID=""Saml2AuthenticationRequest_Read_NoACS""
+  Version=""2.0""
+  Destination=""http://destination.example.com""
+  IssueInstant=""2004-12-05T09:21:59Z"">
+  <saml:Issuer>https://sp.example.com/SAML2</saml:Issuer>
+  <samlp:NameIDPolicy Format=""urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"" AllowCreate=""xxx""></samlp:NameIDPolicy>
+</samlp:AuthnRequest>
+";
+
+            var subject = Saml2AuthenticationRequest.Read(xmlData);
+
+            subject.NameIdPolicy.Should().NotBeNull();
+            subject.NameIdPolicy.Format.Should().Be("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress");
+            subject.NameIdPolicy.AllowCreate.Should().Be(false);
+        }
+
         [TestMethod]
         public void Saml2AuthenticationRequest_Read_ShouldThrowOnInvalidMessageName()
         {

--- a/Kentor.AuthServices/Kentor.AuthServices.csproj
+++ b/Kentor.AuthServices/Kentor.AuthServices.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Internal\QueryStringHelper.cs" />
     <Compile Include="Metadata\KeyInfoSerializer.cs" />
     <Compile Include="Saml2P\FilteringXmlNodeReader.cs" />
+    <Compile Include="Saml2P\Saml2NameIdPolicy.cs" />
     <Compile Include="Saml2ResponseFailedValidationException.cs" />
     <Compile Include="WebSso\AcsCommand.cs" />
     <Compile Include="Metadata\AttributeConsumingService.cs" />

--- a/Kentor.AuthServices/SAML2P/Saml2AuthenticationRequest.cs
+++ b/Kentor.AuthServices/SAML2P/Saml2AuthenticationRequest.cs
@@ -64,7 +64,9 @@ namespace Kentor.AuthServices.Saml2P
         public static Saml2AuthenticationRequest Read(string xml)
         {
             if (xml == null)
+            {
                 return null;
+            }
             
             var x = new XmlDocument {PreserveWhitespace = true};
             x.LoadXml(xml);

--- a/Kentor.AuthServices/SAML2P/Saml2AuthenticationRequest.cs
+++ b/Kentor.AuthServices/SAML2P/Saml2AuthenticationRequest.cs
@@ -64,11 +64,9 @@ namespace Kentor.AuthServices.Saml2P
         public static Saml2AuthenticationRequest Read(string xml)
         {
             if (xml == null)
-            {
                 return null;
-            }
-            var x = new XmlDocument();
-            x.PreserveWhitespace = true;
+            
+            var x = new XmlDocument {PreserveWhitespace = true};
             x.LoadXml(xml);
 
             return new Saml2AuthenticationRequest(x);
@@ -84,6 +82,17 @@ namespace Kentor.AuthServices.Saml2P
             {
                 AssertionConsumerServiceUrl = new Uri(AssertionConsumerServiceUriString);
             }
+
+            var nameIdPolicyElement = xml.DocumentElement["NameIDPolicy", Saml2Namespaces.Saml2PName];
+            if (nameIdPolicyElement == null) return;
+            
+            bool allowCreate;
+            bool.TryParse(nameIdPolicyElement.Attributes["AllowCreate"].GetValueIfNotNull(), out allowCreate);
+            NameIdPolicy = new Saml2NameIdPolicy
+            {
+                Format = nameIdPolicyElement.Attributes["Format"].GetValueIfNotNull(),
+                AllowCreate = allowCreate
+            };
         }
 
         /// <summary>
@@ -95,5 +104,10 @@ namespace Kentor.AuthServices.Saml2P
         /// Index to the SP metadata where the list of requested attributes is found.
         /// </summary>
         public int? AttributeConsumingServiceIndex { get; set; }
+
+        /// <summary>
+        /// NameIDPolicy
+        /// </summary>
+        public Saml2NameIdPolicy NameIdPolicy { get; set; }
     }
 }

--- a/Kentor.AuthServices/SAML2P/Saml2NameIdPolicy.cs
+++ b/Kentor.AuthServices/SAML2P/Saml2NameIdPolicy.cs
@@ -1,0 +1,18 @@
+﻿namespace Kentor.AuthServices.Saml2P
+{
+    /// <summary>
+    /// NameIDPolicy
+    /// </summary>
+    public class Saml2NameIdPolicy
+    {
+        /// <summary>
+        /// Allow Create
+        /// </summary>
+        public bool AllowCreate { get; set; }
+        /// <summary>
+        /// Format
+        /// </summary>
+        public string Format { get; set; }
+
+    }
+}

--- a/Kentor.AuthServices/SAML2P/Saml2RequestBase.cs
+++ b/Kentor.AuthServices/SAML2P/Saml2RequestBase.cs
@@ -125,6 +125,13 @@ namespace Kentor.AuthServices.Saml2P
             Id = xml.DocumentElement.Attributes["ID"].Value;
 
             Issuer = new EntityId(xml.DocumentElement["Issuer", Saml2Namespaces.Saml2Name].GetTrimmedTextIfNotNull());
+
+            var destinationAttribute = xml.DocumentElement.Attributes["Destination"].GetValueIfNotNull();
+            if (string.IsNullOrWhiteSpace(destinationAttribute)) return;
+            
+            Uri destinationUri;
+            if (Uri.TryCreate(destinationAttribute, UriKind.RelativeOrAbsolute, out destinationUri))
+                DestinationUrl = destinationUri;
         }
 
         private void ValidateCorrectDocument(XmlDocument xml)


### PR DESCRIPTION
Used authservices for the first time and fixed some minor things that I found in regard to the deserialization of the AuthnRequest to POCOs

<!---
@huboard:{"order":0.0009765625,"milestone_order":277,"custom_state":""}
-->
