### PR TITLE
Fix code analysis issue

### DIFF
--- a/Kentor.AuthServices/Federation.cs
+++ b/Kentor.AuthServices/Federation.cs
@@ -137,12 +137,9 @@ namespace Kentor.AuthServices
             }
 
             // Remember what we registered this time, to know what to remove nex time.
-            foreach (var idp in identityProviders)
-            {
-                registeredIdentityProviders = identityProviders.ToDictionary(
-                    i => i.EntityId.Id,
-                    i => i.EntityId);
-            }
+            registeredIdentityProviders = identityProviders.ToDictionary(
+                i => i.EntityId.Id,
+                i => i.EntityId);
         }
 
         private void RemoveAllRegisteredIdentityProviders()


### PR DESCRIPTION
The unused variable `idp` is detected by VS2015 code analysis but was not detected by VS2013