### PR TITLE
Fix for error handling error. 'Saml2Response' key: Item has already been added

### DIFF
--- a/Kentor.AuthServices/WebSSO/AcsCommand.cs
+++ b/Kentor.AuthServices/WebSSO/AcsCommand.cs
@@ -49,13 +49,13 @@ namespace Kentor.AuthServices.WebSso
                         "The SAML response contains incorrect XML", ex);
                     
                     // Add the payload to the exception
-                    newEx.Data.Add("Saml2Response", unpackedPayload);
+                    newEx.Data["Saml2Response"] = unpackedPayload;
                     throw newEx;
                 }
                 catch (Exception ex)
                 {
                     // Add the payload to the existing exception
-                    ex.Data.Add("Saml2Response", unpackedPayload);
+                    ex.Data["Saml2Response"] = unpackedPayload;
                     throw;
                 }
             }


### PR DESCRIPTION
I get exceptions from AcsCommand.Run

>  Message: System.ArgumentException: Item has already been added. Key in dictionary: 'Saml2Response'  Key being added: 'Saml2Response'
>    at System.Collections.ListDictionaryInternal.Add(Object key, Object value)
>    at Kentor.AuthServices.WebSso.AcsCommand.Run(HttpRequestData request, IOptions options)
>    at Kentor.AuthServices.Owin.KentorAuthServicesAuthenticationHandler.<AuthenticateCoreAsync>d__1.MoveNext()

I get the errors only in production and I can't reproduce in dev or test.

This error is unfortunates as it hides the real error by crashing in the error handling.

I can't figure out why the Exception.Data dictionary could already contain an Saml2Response key, but I made a small change to overwrite the entry instead of crashing if it already exists.
The reasoning is that it's better to overwrite an existing value than to crash during error handling.

I don't really like making fixes without understanding why error happen. Any suggestions on what is going on or how to reproduce?