### PR TITLE
Fix failing tests due to different Mvc versions in test and lib

### DIFF
--- a/Kentor.AuthServices.Tests/App.config
+++ b/Kentor.AuthServices.Tests/App.config
@@ -52,6 +52,10 @@
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
Create an assembly binding to get the same MVC version in tests and the MVC project

Fixes failing tests like

	Test Name: AuthServicesController_SignIn_Returns_DiscoveryService
	Test FullName: Kentor.AuthServices.Tests.Mvc.AuthServicesControllerTests.AuthServicesController_SignIn_Returns_DiscoveryService
	Test Source: c:\Git\authservices\Kentor.AuthServices.Tests\Mvc\AuthServicesControllerTests.cs : line 58
	Test Outcome: Failed
	Test Duration: 0:00:00.0043872

	Result Message: Expected type to be [System.Web.Mvc.RedirectResult, System.Web.Mvc, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35], but found [System.Web.Mvc.RedirectResult, System.Web.Mvc, Version=4.0.0.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35].

Fixes regression from commit b91971f9e87a2142cdb6a7d41b831d35009c6774 where the MVC project was changed to MVC4