### PR TITLE
for some reason the metadata return more than one signing key (ADFS), this …

### DIFF
--- a/Kentor.AuthServices/IdentityProvider.cs
+++ b/Kentor.AuthServices/IdentityProvider.cs
@@ -329,7 +329,7 @@ namespace Kentor.AuthServices
 
             var key = idpDescriptor.Keys
                 .Where(k => k.Use == KeyType.Unspecified || k.Use == KeyType.Signing)
-                .SingleOrDefault();
+                .FirstOrDefault();
 
             if (key != null)
             {


### PR DESCRIPTION
…caused an exception