### PR TITLE
Lazy loading of metadata

### DIFF
--- a/Kentor.AuthServices.Tests/App.config
+++ b/Kentor.AuthServices.Tests/App.config
@@ -32,6 +32,7 @@
         <signingCertificate fileName="Kentor.AuthServices.Tests.pfx" />
       </add>
       <add entityId="http://localhost:13428/idpMetadata" allowUnsolicitedAuthnResponse="true" loadMetadata="true" />
+      <add entityId="http://localhost:13428/idpLazyMetadata" allowUnsolicitedAuthnResponse="true" loadMetadata="false" lazyLoadMetadata="true" />
     </identityProviders>
     <federations>
       <add metadataUrl="http://localhost:13428/federationMetadata" allowUnsolicitedAuthnResponse="true" />

--- a/Kentor.AuthServices.Tests/IdentityProviderTests.cs
+++ b/Kentor.AuthServices.Tests/IdentityProviderTests.cs
@@ -189,6 +189,41 @@ namespace Kentor.AuthServices.Tests
         }
 
         [TestMethod]
+        public void IdentityProvider_LazyLoadMetada_MetadataReloadesAfterFirstGetter()
+        {
+            var config = CreateConfig();
+            config.DestinationUrl = null;
+            config.LoadMetadata = false;
+            config.LazyLoadMetadata = true;
+            config.EntityId = "http://localhost:13428/idpLazyMetadata";
+            config.MetadataUrl = new Uri("http://localhost:13428/idpLazyMetadata");
+
+            var subject = new IdentityProvider(config, Options.FromConfiguration.SPOptions);
+
+            var field = typeof(IdentityProvider).GetField("singleSignOnServiceUrl", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            field.GetValue(subject).Should().BeNull();
+            subject.SingleSignOnServiceUrl.Should().Be("http://localhost:13428/acs");
+
+        }
+
+        [TestMethod]
+        public void IdentityProvider_LazydLoadMetadata_SettingMetadataUrlDoesntCauseMetataLoad()
+        {
+            var config = CreateConfig();
+            config.DestinationUrl = null;
+            config.LoadMetadata = false;
+            config.LazyLoadMetadata = true;
+            config.EntityId = "http://localhost:13428/idpLazyMetadata";
+            config.MetadataUrl = new Uri("http://localhost:13428/idpLazyMetadata");
+
+            var subject = new IdentityProvider(config, Options.FromConfiguration.SPOptions);
+
+            var field = typeof(IdentityProvider).GetField("singleSignOnServiceUrl", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            field.GetValue(subject).Should().BeNull();
+            subject.MetadataUrl = new Uri("http://localhost:13428/otheridpLazyMetadata");
+            field.GetValue(subject).Should().BeNull();
+        }
+
         public void IdentityProvider_Ctor_HandlesConfiguredCertificateWhenReadingMetadata()
         {
             var config = CreateConfig();
@@ -293,10 +328,11 @@ namespace Kentor.AuthServices.Tests
             subject.MetadataValidUntil.Should().BeCloseTo(expectedValidUntil, 1000);
         }
 
-        IdentityProvider CreateSubjectForMetadataRefresh()
+        IdentityProvider CreateSubjectForMetadataRefresh(bool loadMetadata = true, bool lazyLoadMetadata = false)
         {
             var config = CreateConfig();
-            config.LoadMetadata = true;
+            config.LoadMetadata = loadMetadata;
+            config.LazyLoadMetadata = lazyLoadMetadata; 
             config.EntityId = "http://localhost:13428/idpMetadataVeryShortCacheDuration";
             return new IdentityProvider(config, Options.FromConfiguration.SPOptions);
         }
@@ -406,6 +442,18 @@ namespace Kentor.AuthServices.Tests
         }
 
         [TestMethod]
+        public void IdentityProvider_ScheduledReloadOfLazyMetadata()
+        {
+            MetadataRefreshScheduler.minInternval = new TimeSpan(0, 0, 0, 0, 1);
+
+            var subject = CreateSubjectForMetadataRefresh(false, true);
+            var initialValidUntil = subject.MetadataValidUntil;
+            var getDataForTheFirstTime = subject.SingleSignOnServiceUrl;
+
+            SpinWaiter.WhileEqual(() => subject.MetadataValidUntil, () => initialValidUntil);
+        }
+
+        [TestMethod]
         public void IdentityProvider_ScheduledReloadOfMetadata_RetriesIfLoadFails()
         {
             MetadataRefreshScheduler.minInternval = new TimeSpan(0, 0, 0, 0, 1);
@@ -417,9 +465,34 @@ namespace Kentor.AuthServices.Tests
             SpinWaiter.While(() => subject.MetadataValidUntil != DateTime.MinValue,
                 "Timed out waiting for failed metadata load to occur.");
 
-            var metadataEnabledTime = DateTime.UtcNow;
             MetadataServer.IdpAndFederationShortCacheDurationAvailable = true;
 
+            SpinWaiter.While(() =>
+            {
+                var mvu = subject.MetadataValidUntil;
+                return !mvu.HasValue || mvu == DateTime.MinValue;
+            },
+            "Timed out waiting for successful reload of metadata.");
+        }
+
+        [TestMethod]
+        public void IdentityProvider_ScheduledReloadOfLazyMetadata_RetriesIfLoadFails()
+        {
+            MetadataRefreshScheduler.minInternval = new TimeSpan(0, 0, 0, 0, 1);
+
+            var subject = CreateSubjectForMetadataRefresh(false, true);
+            var accessedProperty = subject.SigningKeys;
+            subject.MetadataValidUntil.Should().HaveValue();
+            subject.MetadataValidUntil.Should().BeAfter(DateTime.MinValue);
+
+            MetadataServer.IdpAndFederationShortCacheDurationAvailable = false;
+
+            SpinWaiter.While(() => subject.MetadataValidUntil != DateTime.MinValue,
+                "Timed out waiting for failed metadata load to occur.");
+
+            MetadataServer.IdpAndFederationShortCacheDurationAvailable = true;
+
+            accessedProperty = subject.SigningKeys;
             SpinWaiter.While(() =>
             {
                 var mvu = subject.MetadataValidUntil;

--- a/Kentor.AuthServices.Tests/Metadata/MetadataServer.cs
+++ b/Kentor.AuthServices.Tests/Metadata/MetadataServer.cs
@@ -38,6 +38,21 @@ namespace Kentor.AuthServices.Tests.Metadata
   </EntityDescriptor>
 ", SignedXmlHelper.KeyInfoXml, IdpMetadataSsoPort);
 
+            content["/idpLazyMetadata"] = string.Format(
+ @"<EntityDescriptor xmlns=""urn:oasis:names:tc:SAML:2.0:metadata""
+    entityID=""http://localhost:13428/idpLazyMetadata"" validUntil=""2100-01-02T14:42:43Z"">
+    <IDPSSODescriptor
+      protocolSupportEnumeration=""urn:oasis:names:tc:SAML:2.0:protocol"">
+      <KeyDescriptor>
+        {0}
+      </KeyDescriptor>
+      <SingleSignOnService
+        Binding=""urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST""
+        Location=""http://localhost:{1}/acs""/>
+    </IDPSSODescriptor>
+  </EntityDescriptor>
+", SignedXmlHelper.KeyInfoXml, IdpMetadataSsoPort);
+
             content["/idpMetadataNoCertificate"] = 
 @"<EntityDescriptor xmlns=""urn:oasis:names:tc:SAML:2.0:metadata""
     entityID=""http://localhost:13428/idpMetadataNoCertificate"" cacheDuration=""PT15M"">

--- a/Kentor.AuthServices/Configuration/IdentityProviderElement.cs
+++ b/Kentor.AuthServices/Configuration/IdentityProviderElement.cs
@@ -121,6 +121,23 @@ namespace Kentor.AuthServices.Configuration
             }
         }
 
+        /// <summary>
+        /// Enable automatic downloading of metadata form the well-known uri only when the provider is actually used. 
+        /// Use when LoadMetadata = false.
+        /// </summary>
+        [ConfigurationProperty("lazyLoadMetadata", IsRequired = false, DefaultValue = false)]
+        public bool LazyLoadMetadata
+        {
+            get
+            {
+                return (bool)base["lazyLoadMetadata"];
+            }
+            set
+            {
+                base["lazyLoadMetadata"] = value;
+            }
+        }
+
         const string metadataUrl = "metadataUrl";
 
         /// <summary>


### PR DESCRIPTION
- this loads metadata only if the provider is used. Might be useful if some providers are unreachable and waiting for them to timeout causes unnecessary blocking on the start