### PR TITLE
Throwing null ref exception if options is null on get claim

### DIFF
--- a/Kentor.AuthServices.Tests/Saml2P/Saml2ResponseTests.cs
+++ b/Kentor.AuthServices.Tests/Saml2P/Saml2ResponseTests.cs
@@ -1506,6 +1506,38 @@ namespace Kentor.AuthServices.Tests.Saml2P
         }
 
         [TestMethod]
+        public void Saml2Response_GetClaims_ThrowsOnEmptyOptions()
+        {
+            var response =
+            @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            <saml2p:Response xmlns:saml2p=""urn:oasis:names:tc:SAML:2.0:protocol""
+            xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+            ID = """ + MethodBase.GetCurrentMethod().Name + @""" Version=""2.0"" IssueInstant=""2013-01-01T00:00:00Z"">
+                <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                <saml2p:Status>
+                    <saml2p:StatusCode Value=""urn:oasis:names:tc:SAML:2.0:status:Requester"" />
+                </saml2p:Status>
+                <saml2:Assertion
+                Version=""2.0"" ID=""" + MethodBase.GetCurrentMethod().Name + @"_Assertion""
+                IssueInstant=""2013-09-25T00:00:00Z"">
+                    <saml2:Issuer>https://idp.example.com</saml2:Issuer>
+                    <saml2:Subject>
+                        <saml2:NameID>SomeUser</saml2:NameID>
+                        <saml2:SubjectConfirmation Method=""urn:oasis:names:tc:SAML:2.0:cm:bearer"" />
+                    </saml2:Subject>
+                    <saml2:Conditions NotOnOrAfter=""2100-01-01T00:00:00Z"" />
+                </saml2:Assertion>
+            </saml2p:Response>";
+
+            var xml = SignedXmlHelper.SignXml(response);
+
+            var subject = Saml2Response.Read(xml);
+
+            Action a = () => subject.GetClaims(null);
+            a.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("options");
+        }
+
+        [TestMethod]
         public void Saml2Response_GetClaims_ThrowsOnStatusFailure()
         {
             var response =

--- a/Kentor.AuthServices/SAML2P/Saml2Response.cs
+++ b/Kentor.AuthServices/SAML2P/Saml2Response.cs
@@ -473,6 +473,10 @@ namespace Kentor.AuthServices.Saml2P
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         public IEnumerable<ClaimsIdentity> GetClaims(IOptions options)
         {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
             if (createClaimsException != null)
             {
                 throw createClaimsException;


### PR DESCRIPTION
It would make more sense to not check against full exception text, but I am not that good at Fluent assertions. This is what would probably make more sense in unit test: 
````
a.ShouldThrow<ArgumentNullException>()
                .Where(x => x.Message.Should().Contain("options"));
`````