### PR TITLE
Remove invalid XML declaration from HTML-page in Saml2PostBinding

### DIFF
--- a/Kentor.AuthServices.Tests/WebSSO/Saml2PostBindingTests.cs
+++ b/Kentor.AuthServices.Tests/WebSSO/Saml2PostBindingTests.cs
@@ -88,7 +88,7 @@ namespace Kentor.AuthServices.Tests.WebSso
             var expected = new CommandResult()
             {
                 ContentType = "text/html",
-                Content = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+                Content = @"
 <!DOCTYPE html PUBLIC ""-//W3C//DTD XHTML 1.1//EN""
 ""http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"">
 <html xmlns=""http://www.w3.org/1999/xhtml"" xml:lang=""en"">

--- a/Kentor.AuthServices/WebSSO/Saml2PostBinding.cs
+++ b/Kentor.AuthServices/WebSSO/Saml2PostBinding.cs
@@ -64,7 +64,7 @@ namespace Kentor.AuthServices.WebSso
             return cr;
         }
 
-        private const string PostHtmlFormatString = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+        private const string PostHtmlFormatString = @"
 <!DOCTYPE html PUBLIC ""-//W3C//DTD XHTML 1.1//EN""
 ""http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"">
 <html xmlns=""http://www.w3.org/1999/xhtml"" xml:lang=""en"">


### PR DESCRIPTION
I suppose the Saml2PostBinding posting page should not begin with an XML-declaration.