### PR TITLE
StubIDP: Compress user list to save bandwidth and improve loading times

### DIFF
--- a/Kentor.AuthServices.StubIdp/CompressAttribute.cs
+++ b/Kentor.AuthServices.StubIdp/CompressAttribute.cs
@@ -1,0 +1,32 @@
+﻿// From http://stackoverflow.com/a/3802424/401728
+using System;
+using System.IO.Compression;
+using System.Web.Mvc;
+
+/// <summary>
+/// Attribute for compressing with deflate or gzip depending on request Accept-Encoding header
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public class CompressAttribute : ActionFilterAttribute
+{
+    public override void OnActionExecuting(ActionExecutingContext filterContext)
+    {
+
+        var encodingsAccepted = filterContext.HttpContext.Request.Headers["Accept-Encoding"];
+        if (string.IsNullOrEmpty(encodingsAccepted)) return;
+
+        encodingsAccepted = encodingsAccepted.ToLowerInvariant();
+        var response = filterContext.HttpContext.Response;
+
+        if (encodingsAccepted.Contains("deflate"))
+        {
+            response.AppendHeader("Content-encoding", "deflate");
+            response.Filter = new DeflateStream(response.Filter, CompressionMode.Compress);
+        }
+        else if (encodingsAccepted.Contains("gzip"))
+        {
+            response.AppendHeader("Content-encoding", "gzip");
+            response.Filter = new GZipStream(response.Filter, CompressionMode.Compress);
+        }
+    }
+}

--- a/Kentor.AuthServices.StubIdp/Controllers/ManageController.cs
+++ b/Kentor.AuthServices.StubIdp/Controllers/ManageController.cs
@@ -82,6 +82,7 @@ namespace Kentor.AuthServices.StubIdp.Controllers
             return RedirectToAction("Index");
         }
 
+        [Compress]
         public ActionResult CurrentConfiguration(Guid? idpId)
         {
             var fileData = GetCachedConfiguration(idpId.GetValueOrDefault(defaultIdpGuid));

--- a/Kentor.AuthServices.StubIdp/Kentor.AuthServices.StubIdp.csproj
+++ b/Kentor.AuthServices.StubIdp/Kentor.AuthServices.StubIdp.csproj
@@ -156,6 +156,7 @@
     <Compile Include="App_Start\LessTransform.cs" />
     <Compile Include="App_Start\RouteConfig.cs" />
     <Compile Include="CertificateHelper.cs" />
+    <Compile Include="CompressAttribute.cs" />
     <Compile Include="Controllers\CertificateController.cs" />
     <Compile Include="Controllers\DiscoveryServiceController.cs" />
     <Compile Include="Controllers\FederationController.cs" />


### PR DESCRIPTION
The JSON data describing the available users in the StubIDP may grow quite large and benefits a lot from compression.
This compression saves about 95% of the transferred data size on large user lists.
The solution with a custom attribute makes the compression work regardless of hosting solution and server configuration.
An alternative would be to activate Dynamic content compression in IIS, but that would require manual configuration and component installation on each server.