### PR TITLE
Adding secondary level status code for saml response

### DIFF
--- a/Kentor.AuthServices.Tests/InvalidSamlOperationExceptionTest.cs
+++ b/Kentor.AuthServices.Tests/InvalidSamlOperationExceptionTest.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+namespace Kentor.AuthServices.Tests
+{
+    [TestClass]
+    public class InvalidSamlOperationExceptionTest
+    {
+        [TestMethod]
+        public void InvalidSamlOperationException_DefaultCtor()
+        {
+            ExceptionTestHelpers.TestDefaultCtor<InvalidSamlOperationException>();
+        }
+
+        [TestMethod]
+        public void InvalidSamlOperationException_SerializationCtor()
+        {
+            ExceptionTestHelpers.TestSerializationCtor<InvalidSamlOperationException>();
+        }
+
+        [TestMethod]
+        public void InvalidSamlOperationException_StringCtor()
+        {
+            var msg = "Message!";
+            var subject = new InvalidSamlOperationException(msg);
+
+            subject.Message.Should().Be(msg);
+        }
+        [TestMethod]
+        public void InvalidSamlOperationException_StringInnerExCtor()
+        {
+            var msg = "Message!";
+            var inner = new Exception();
+            var subject = new InvalidSamlOperationException(msg, inner);
+
+            subject.Message.Should().Be(msg);
+            subject.InnerException.Should().Be(inner);
+        }
+
+    }
+}

--- a/Kentor.AuthServices.Tests/Kentor.AuthServices.Tests.csproj
+++ b/Kentor.AuthServices.Tests/Kentor.AuthServices.Tests.csproj
@@ -116,6 +116,7 @@
     <Compile Include="HttpModule\HttpRequestBaseExtensionsTests.cs" />
     <Compile Include="Internal\QueryStringHelperTests.cs" />
     <Compile Include="Internal\PathHelperTests.cs" />
+    <Compile Include="InvalidSamlOperationExceptionTest.cs" />
     <Compile Include="Metadata\MetadatabaseExtensionsTests.cs" />
     <Compile Include="Mvc\AuthServicesControllerTests.cs" />
     <Compile Include="ClaimsAuthenticationManagerStub.cs" />

--- a/Kentor.AuthServices/InvalidSAMLOperationException.cs
+++ b/Kentor.AuthServices/InvalidSAMLOperationException.cs
@@ -1,0 +1,84 @@
+﻿using Kentor.AuthServices.Saml2P;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kentor.AuthServices
+{
+    /// <summary>
+    /// Extended exception containing information about the status and status message SAML response.  
+    /// </summary>
+    [Serializable]
+    public class InvalidSamlOperationException: InvalidOperationException
+    {
+        /// <summary>
+        /// Status of the SAML2Response
+        /// </summary>
+        public Saml2StatusCode Status { get; set; }
+        /// <summary>
+        /// Status message of SAML2Response
+        /// </summary>
+        public string StatusMessage { get; set; }
+
+        /// <summary>
+        /// Second level status of SAML2Response
+        /// </summary>
+        public string SecondLevelStatus { get; set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="message">Exception message.</param>
+        /// <param name="statusCode">Status of the SAML2Response</param>
+        /// <param name="statusMessage">Status message of SAML2Response</param>
+        /// <param name="secondLevelStatus">Second level status of SAML2Response</param>
+        public InvalidSamlOperationException(string message, Saml2StatusCode statusCode, string statusMessage, string secondLevelStatus) : base(message)
+        {
+            this.Status = statusCode;
+            this.StatusMessage = statusMessage;
+            this.SecondLevelStatus = secondLevelStatus;
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        public InvalidSamlOperationException() : base()
+        {
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="message"></param>
+        public InvalidSamlOperationException(string message) : base(message)
+        {
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="innerException"></param>
+        public InvalidSamlOperationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="info"></param>
+        /// <param name="context"></param>
+        protected InvalidSamlOperationException(SerializationInfo info, StreamingContext context): base(info, context)
+        {
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="info"></param>
+        /// <param name="context"></param>
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+        }
+
+    }
+}

--- a/Kentor.AuthServices/Kentor.AuthServices.csproj
+++ b/Kentor.AuthServices/Kentor.AuthServices.csproj
@@ -56,6 +56,7 @@
     <Compile Include="ConfiguredAndLoadedCollection.cs" />
     <Compile Include="Internal\PathHelper.cs" />
     <Compile Include="Internal\QueryStringHelper.cs" />
+    <Compile Include="InvalidSAMLOperationException.cs" />
     <Compile Include="Metadata\KeyInfoSerializer.cs" />
     <Compile Include="Saml2P\FilteringXmlNodeReader.cs" />
     <Compile Include="Saml2ResponseFailedValidationException.cs" />

--- a/Kentor.AuthServices/SAML2P/Saml2Response.cs
+++ b/Kentor.AuthServices/SAML2P/Saml2Response.cs
@@ -72,6 +72,10 @@ namespace Kentor.AuthServices.Saml2P
 
             statusMessage = xml.DocumentElement["Status", Saml2Namespaces.Saml2PName]
                 ["StatusMessage", Saml2Namespaces.Saml2PName].GetTrimmedTextIfNotNull();
+            if (xml.DocumentElement["Status", Saml2Namespaces.Saml2PName]["StatusCode", Saml2Namespaces.Saml2PName]["StatusCode", Saml2Namespaces.Saml2PName] != null)
+            {
+                secondLevelStatus = xml.DocumentElement["Status", Saml2Namespaces.Saml2PName]["StatusCode", Saml2Namespaces.Saml2PName]["StatusCode", Saml2Namespaces.Saml2PName].Value;
+            } 
 
             issuer = new EntityId(xmlDocument.DocumentElement["Issuer", Saml2Namespaces.Saml2Name].GetTrimmedTextIfNotNull());
 
@@ -227,6 +231,13 @@ namespace Kentor.AuthServices.Saml2P
         /// StatusMessage of the message according to the SAML2 spec section 3.2.2.1
         /// </summary>
         public string StatusMessage { get { return statusMessage; } }
+
+        readonly string secondLevelStatus;
+        /// <summary>
+        /// Optional status which MAY give additional information about the cause of the problem (according to the SAML2 spec section 3.2.2.2))))))))). 
+        /// Because it may change in future specifications let's not make enum out of it yet.
+        /// </summary>
+        public string SecondLevelStatus { get { return secondLevelStatus; } }
 
         readonly EntityId issuer;
 
@@ -504,8 +515,9 @@ namespace Kentor.AuthServices.Saml2P
 
             if (status != Saml2StatusCode.Success)
             {
-                throw new InvalidOperationException(string.Format("The Saml2Response must have status success to extract claims. Status: {0}.{1}"
-                    , status.ToString(), statusMessage != null ? " Message: " + statusMessage + "." : string.Empty));
+                throw new InvalidSamlOperationException(string.Format("The Saml2Response must have status success to extract claims. Status: {0}.{1}"
+                , status.ToString(), statusMessage != null ? " Message: " + statusMessage + "." : string.Empty),
+                status, statusMessage, secondLevelStatus);
             }
 
             foreach (XmlElement assertionNode in AllAssertionElementNodes)


### PR DESCRIPTION
Adding secondary level status code for saml response as defined in 3.2.2.2 of the Assertions and Protocols for the OASIS Security Assertion Markup Language

- this adds an additional string field for the secondary status message, the field is intentionally a string because specification says this status can change in future versions of protocol
- additional exception has been added to get the statuscode and secondary status code if the STS response is other than Success the information about the status code may be helpful outside the module.