### PR TITLE
Possible refactoring of configuration loading

### DIFF
--- a/Kentor.AuthServices.Owin/KentorAuthServicesAuthenticationOptions.cs
+++ b/Kentor.AuthServices.Owin/KentorAuthServicesAuthenticationOptions.cs
@@ -31,7 +31,7 @@ namespace Kentor.AuthServices.Owin
 
             if (loadConfiguration)
             {
-                SPOptions = KentorAuthServicesSection.Current;
+                SPOptions = new SPOptions(KentorAuthServicesSection.Current);
                 KentorAuthServicesSection.Current.IdentityProviders.RegisterIdentityProviders(this);
                 KentorAuthServicesSection.Current.Federations.RegisterFederations(this);
             }

--- a/Kentor.AuthServices.Tests/Configuration/SPOptionsTests.cs
+++ b/Kentor.AuthServices.Tests/Configuration/SPOptionsTests.cs
@@ -26,6 +26,13 @@ namespace Kentor.AuthServices.Tests.Configuration
                 .Should().Contain(new Uri(entityId));
         }
 
+        [TestMethod]
+        public void SPOptions_Constructor_ThrowsOnNullConfiguration()
+        {
+            Action a = () => new SPOptions((KentorAuthServicesSection)null); ;
+
+            a.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("configSection");
+        }
 
         [TestMethod]
         public void SPOptions_EntityId_SettingThrowsIfTokenHandlerCreated()

--- a/Kentor.AuthServices/Configuration/KentorAuthServicesSection.cs
+++ b/Kentor.AuthServices/Configuration/KentorAuthServicesSection.cs
@@ -5,15 +5,8 @@ using System.Configuration;
 using System.Globalization;
 using System.IdentityModel.Metadata;
 using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Kentor.AuthServices.Internal;
 using Kentor.AuthServices.Metadata;
-using Kentor.AuthServices.Saml2P;
-using System.IdentityModel.Configuration;
-using System.IdentityModel.Services.Configuration;
-using System.Security.Cryptography.X509Certificates;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Kentor.AuthServices.Configuration
@@ -21,7 +14,7 @@ namespace Kentor.AuthServices.Configuration
     /// <summary>
     /// Config section for the module.
     /// </summary>
-    public class KentorAuthServicesSection : ConfigurationSection, ISPOptions
+    public class KentorAuthServicesSection : ConfigurationSection
     {
         private static readonly KentorAuthServicesSection current =
             (KentorAuthServicesSection)ConfigurationManager.GetSection("kentor.authServices");
@@ -41,16 +34,6 @@ namespace Kentor.AuthServices.Configuration
         public override bool IsReadOnly()
         {
             return !allowChange;
-        }
-
-        /// <summary>
-        /// Ctor
-        /// </summary>
-        public KentorAuthServicesSection()
-        {
-            saml2PSecurityTokenHandler = new Lazy<Saml2PSecurityTokenHandler>(
-                () => new Saml2PSecurityTokenHandler(this),
-                true);
         }
 
         /// <summary>
@@ -137,19 +120,6 @@ namespace Kentor.AuthServices.Configuration
             get
             {
                 return (Uri)base[discoveryServiceUrl];
-            }
-        }
-
-        private readonly Lazy<Saml2PSecurityTokenHandler> saml2PSecurityTokenHandler;
-
-        /// <summary>
-        /// The security token handler used to process incoming assertions for this SP.
-        /// </summary>
-        public Saml2PSecurityTokenHandler Saml2PSecurityTokenHandler
-        {
-            get
-            {
-                return saml2PSecurityTokenHandler.Value;
             }
         }
 
@@ -289,26 +259,12 @@ namespace Kentor.AuthServices.Configuration
             }
         }
 
-        private IdentityConfiguration systemIdentityModelIdentityConfiguration
-            = new IdentityConfiguration(true);
-
-        /// <summary>
-        /// The System.IdentityModel configuration to use.
-        /// </summary>
-        public IdentityConfiguration SystemIdentityModelIdentityConfiguration
-        {
-            get
-            {
-                return systemIdentityModelIdentityConfiguration;
-            }
-        }
-
         /// <summary>
         /// Certificate location for the certificate the Service Provider uses to decrypt assertions.
         /// </summary>
         [ConfigurationProperty("serviceCertificate")]
         [ExcludeFromCodeCoverage]
-        public CertificateElement ServiceCertificateConfiguration
+        public CertificateElement ServiceCertificate
         {
             get
             {
@@ -319,10 +275,5 @@ namespace Kentor.AuthServices.Configuration
                 base["serviceCertificate"] = value;
             }
         }
-
-        /// <summary>
-        /// Certificate for service provider to use when decrypting assertions
-        /// </summary>
-        public X509Certificate2 ServiceCertificate { get; set; }
     }
 }

--- a/Kentor.AuthServices/Configuration/Options.cs
+++ b/Kentor.AuthServices/Configuration/Options.cs
@@ -24,13 +24,21 @@ namespace Kentor.AuthServices.Configuration
         {
             get
             {
-                var options = new Options(KentorAuthServicesSection.Current);
-                KentorAuthServicesSection.Current.IdentityProviders.RegisterIdentityProviders(options);
-                KentorAuthServicesSection.Current.Federations.RegisterFederations(options);
-                options.SPOptions.ServiceCertificate = KentorAuthServicesSection.Current.ServiceCertificateConfiguration.LoadCertificate();
-
-                return options;
+                return optionsFromConfiguration.Value;
             }
+        }
+
+        private static readonly Lazy<Options> optionsFromConfiguration 
+            = new Lazy<Options>(() => LoadOptionsFromConfiguration(), false);
+
+        private static Options LoadOptionsFromConfiguration()
+        {
+            var options = new Options(KentorAuthServicesSection.Current);
+            KentorAuthServicesSection.Current.IdentityProviders.RegisterIdentityProviders(options);
+            KentorAuthServicesSection.Current.Federations.RegisterFederations(options);
+            options.SPOptions.ServiceCertificate = KentorAuthServicesSection.Current.ServiceCertificateConfiguration.LoadCertificate();
+
+            return options;
         }
 
         /// <summary>

--- a/Kentor.AuthServices/Configuration/Options.cs
+++ b/Kentor.AuthServices/Configuration/Options.cs
@@ -29,7 +29,7 @@ namespace Kentor.AuthServices.Configuration
         }
 
         private static readonly Lazy<Options> optionsFromConfiguration 
-            = new Lazy<Options>(() => LoadOptionsFromConfiguration(), false);
+            = new Lazy<Options>(() => LoadOptionsFromConfiguration(), true);
 
         private static Options LoadOptionsFromConfiguration()
         {

--- a/Kentor.AuthServices/Configuration/Options.cs
+++ b/Kentor.AuthServices/Configuration/Options.cs
@@ -33,10 +33,10 @@ namespace Kentor.AuthServices.Configuration
 
         private static Options LoadOptionsFromConfiguration()
         {
-            var options = new Options(KentorAuthServicesSection.Current);
+            var spOptions = new SPOptions(KentorAuthServicesSection.Current);
+            var options = new Options(spOptions);
             KentorAuthServicesSection.Current.IdentityProviders.RegisterIdentityProviders(options);
             KentorAuthServicesSection.Current.Federations.RegisterFederations(options);
-            options.SPOptions.ServiceCertificate = KentorAuthServicesSection.Current.ServiceCertificateConfiguration.LoadCertificate();
 
             return options;
         }

--- a/Kentor.AuthServices/Configuration/SPOptions.cs
+++ b/Kentor.AuthServices/Configuration/SPOptions.cs
@@ -203,8 +203,7 @@ namespace Kentor.AuthServices.Configuration
             }
         }
 
-        private IdentityConfiguration systemIdentityModelIdentityConfiguration
-            = new IdentityConfiguration(false);
+        private IdentityConfiguration systemIdentityModelIdentityConfiguration;
 
         /// <summary>
         /// The System.IdentityModel configuration to use.

--- a/Kentor.AuthServices/Configuration/SPOptions.cs
+++ b/Kentor.AuthServices/Configuration/SPOptions.cs
@@ -23,7 +23,39 @@ namespace Kentor.AuthServices.Configuration
         /// </summary>
         public SPOptions()
         {
+            systemIdentityModelIdentityConfiguration = new IdentityConfiguration(false);
             MetadataCacheDuration = new TimeSpan(1, 0, 0);
+        }
+
+        /// <summary>
+        /// Construct the options from the given configuration section
+        /// </summary>
+        /// <param name="configSection"></param>
+        public SPOptions(KentorAuthServicesSection configSection)
+        {
+            if (configSection == null)
+            {
+                throw new ArgumentNullException(nameof(configSection));
+            }
+            systemIdentityModelIdentityConfiguration = new IdentityConfiguration(true);
+
+            ReturnUrl = configSection.ReturnUrl;
+            MetadataCacheDuration = configSection.MetadataCacheDuration;
+            DiscoveryServiceUrl = configSection.DiscoveryServiceUrl;
+            EntityId = configSection.EntityId;
+            ModulePath = configSection.ModulePath;
+            Organization = configSection.Organization;
+            ServiceCertificate = configSection.ServiceCertificate.LoadCertificate();
+
+            foreach (var acs in configSection.AttributeConsumingServices)
+            {
+                AttributeConsumingServices.Add(acs);
+            }
+
+            foreach (var contact in configSection.Contacts)
+            {
+                Contacts.Add(contact);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
For discussion....

In my opinion, having `KentorAuthServicesSection` implement `ISPOptions` mixes two different concerns in one file (e.g. see the removed lines in this PR that are strictly for `ISPOptions` but don't relate to reading from config file) and make it difficult to have an `ISPOption` property of a different type than we need for reading from config files. Note that `KentorAuthServicesSection` does *not* implement `IOptions`. This lets it to have an `IdentityProviders` property that is of a different type. I'm looking to have that same flexibility e.g. for the `ServiceCertificates` property for #355.

However, I struggled with where to put the "adapter" code that converts from the xml-config-reading objects into the in-memory config objects. For the moment I decided to follow the existing pattern where `IdentityProvider` has constructor that accepts an `IdentityProviderElement`, but I'm open to better ideas on this.

This PR also makes the entire object returned from `FromConfiguration` a singleton rather than just the SPOptions portion of it.



<!---
@huboard:{"order":355.5,"milestone_order":358.0,"custom_state":""}
-->
