### PR TITLE
Fix StubIdp css bundle "403 Forbidden"

### DIFF
--- a/Kentor.AuthServices.StubIdp/App_Start/BundleConfig.cs
+++ b/Kentor.AuthServices.StubIdp/App_Start/BundleConfig.cs
@@ -11,7 +11,7 @@ namespace Kentor.AuthServices.StubIdp
     {
         public static void RegisterBundles(BundleCollection bundles)
         {
-            bundles.Add(new Bundle("~/Content/css")
+            bundles.Add(new Bundle("~/Content/css-bundle")
                 {
                     Transforms = { new LessTransform() }
                 }

--- a/Kentor.AuthServices.StubIdp/Views/Shared/_Layout.cshtml
+++ b/Kentor.AuthServices.StubIdp/Views/Shared/_Layout.cshtml
@@ -3,7 +3,7 @@
 <html>
 <head>
     <title>Kentor.AuthServices Stub Idp</title>
-    @System.Web.Optimization.Styles.Render("~/Content/css")
+    @System.Web.Optimization.Styles.Render("~/Content/css-bundle")
     @System.Web.Optimization.Scripts.Render("~/Scripts/js")
     <meta name="description" content="A stub idp for testing" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
Bundles can't have the same name as an existing folder, in this case ~/Content/css

This gives "403 Forbidden".
See http://stackoverflow.com/a/23159562/401728