### PR TITLE
Ignore SPSSODescriptor when parsing metadata

### DIFF
--- a/Kentor.AuthServices.Tests/ExtendedMetadataSerializerTests.cs
+++ b/Kentor.AuthServices.Tests/ExtendedMetadataSerializerTests.cs
@@ -301,33 +301,9 @@ gosrSG6sO3IPeL4BncKqqZO2FokfZbaqPBv6xmoKsVTUTQRfNEks84dRiG0MjqBncR+B6CIrCv2a
 
             var organizationInfo = entityDescriptor.Organization;
 
-            organizationInfo.Names[0].Name.Should().Be("Test Org");
-            organizationInfo.DisplayNames[0].Name.Should().Be("Test Org Name");
-            organizationInfo.Urls.Count.Should().Be(2);
-        }
-
-        [TestMethod]
-        public void ExtendedMetadataSerializer_Read_Organization_IgnoreDuplicateLanguages()
-        {
-            var data =
-@"<md:EntityDescriptor xmlns:md=""urn:oasis:names:tc:SAML:2.0:metadata"" entityID=""http://idp-acc.test.ek.sll.se/neas"">
-    <md:Organization>
-      <md:OrganizationName xml:lang=""en"">Test Org</md:OrganizationName>
-      <md:OrganizationDisplayName xml:lang=""en"">Test Org Name</md:OrganizationDisplayName>
-      <md:OrganizationURL xml:lang=""en"">https://idp.maggie.bif.ost.se:9445/idp/saml</md:OrganizationURL>
-      <md:OrganizationURL xml:lang=""da"">https://idp.maggie.bif.ost.se:9445/idp/saml</md:OrganizationURL>
-      <md:OrganizationURL xml:lang=""en"">https://idp.maggie.bif.ost.se:9445/idp/saml</md:OrganizationURL>
-    </md:Organization>
-  </md:EntityDescriptor>";
-
-            var entityDescriptor = (ExtendedEntityDescriptor)ExtendedMetadataSerializer.ReaderInstance.ReadMetadata(
-                new MemoryStream(Encoding.UTF8.GetBytes(data)));
-
-            var organizationInfo = entityDescriptor.Organization;
-
-            organizationInfo.Urls.Count.Should().Be(2);
-            organizationInfo.Urls[0].Language.Should().Be(new CultureInfo("en"));
-            organizationInfo.Urls[1].Language.Should().Be(new CultureInfo("da"));
+            organizationInfo.Names.Count.Should().Be(0);
+            organizationInfo.DisplayNames.Count.Should().Be(0);
+            organizationInfo.Urls.Count.Should().Be(0);
         }
     }
 }

--- a/Kentor.AuthServices.Tests/ExtendedMetadataSerializerTests.cs
+++ b/Kentor.AuthServices.Tests/ExtendedMetadataSerializerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
 using System.Text;
@@ -260,6 +261,73 @@ gosrSG6sO3IPeL4BncKqqZO2FokfZbaqPBv6xmoKsVTUTQRfNEks84dRiG0MjqBncR+B6CIrCv2a
 
             keyInfo.Count.Should().Be(1);
             keyInfo[0].Should().BeOfType<RsaKeyIdentifierClause>();
+        }
+
+        [TestMethod]
+        public void ExtendedMetadataSerializer_Read_ServiceProviderSingleSignOnDescriptor()
+        {
+            var data =
+@"<md:EntityDescriptor xmlns:md=""urn:oasis:names:tc:SAML:2.0:metadata"" entityID=""http://idp-acc.test.ek.sll.se/neas"">
+    <md:SPSSODescriptor AuthnRequestsSigned=""false"" WantAssertionsSigned=""true"" protocolSupportEnumeration=""urn:oasis:names:tc:SAML:2.0:protocol"">
+      <md:SingleLogoutService Binding=""urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"" Location=""https://maggie.bif.ost.se:9443/sp/saml/slo/HTTP-POST""/>
+      <md:AssertionConsumerService Binding=""urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"" Location=""https://maggie.bif.ost.se:9443/sp/saml/sso/HTTP-POST"" index=""1"" isDefault=""true""/>
+      <md:AssertionConsumerService Binding=""urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"" Location=""https://maggie.bif.ost.se:9443/sp/saml/sso/POST"" index=""1"" isDefault=""true""/>
+	</md:SPSSODescriptor>
+ </md:EntityDescriptor>";
+
+            var entityDescriptor = (ExtendedEntityDescriptor)ExtendedMetadataSerializer.ReaderInstance.ReadMetadata(
+                new MemoryStream(Encoding.UTF8.GetBytes(data)));
+
+            var spssoInfo = entityDescriptor.RoleDescriptors.Cast<ServiceProviderSingleSignOnDescriptor>().Single();
+
+            spssoInfo.AssertionConsumerServices.Count.Should().Be(0);
+        }
+
+        [TestMethod]
+        public void ExtendedMetadataSerializer_Read_Organization()
+        {
+            var data =
+@"<md:EntityDescriptor xmlns:md=""urn:oasis:names:tc:SAML:2.0:metadata"" entityID=""http://idp-acc.test.ek.sll.se/neas"">
+    <md:Organization>
+      <md:OrganizationName xml:lang=""en"">Test Org</md:OrganizationName>
+      <md:OrganizationDisplayName xml:lang=""en"">Test Org Name</md:OrganizationDisplayName>
+      <md:OrganizationURL xml:lang=""en"">https://idp.maggie.bif.ost.se:9445/idp/saml</md:OrganizationURL>
+      <md:OrganizationURL xml:lang=""da"">https://idp.maggie.bif.ost.se:9445/idp/saml</md:OrganizationURL>
+    </md:Organization>
+  </md:EntityDescriptor>";
+
+            var entityDescriptor = (ExtendedEntityDescriptor)ExtendedMetadataSerializer.ReaderInstance.ReadMetadata(
+                new MemoryStream(Encoding.UTF8.GetBytes(data)));
+
+            var organizationInfo = entityDescriptor.Organization;
+
+            organizationInfo.Names[0].Name.Should().Be("Test Org");
+            organizationInfo.DisplayNames[0].Name.Should().Be("Test Org Name");
+            organizationInfo.Urls.Count.Should().Be(2);
+        }
+
+        [TestMethod]
+        public void ExtendedMetadataSerializer_Read_Organization_IgnoreDuplicateLanguages()
+        {
+            var data =
+@"<md:EntityDescriptor xmlns:md=""urn:oasis:names:tc:SAML:2.0:metadata"" entityID=""http://idp-acc.test.ek.sll.se/neas"">
+    <md:Organization>
+      <md:OrganizationName xml:lang=""en"">Test Org</md:OrganizationName>
+      <md:OrganizationDisplayName xml:lang=""en"">Test Org Name</md:OrganizationDisplayName>
+      <md:OrganizationURL xml:lang=""en"">https://idp.maggie.bif.ost.se:9445/idp/saml</md:OrganizationURL>
+      <md:OrganizationURL xml:lang=""da"">https://idp.maggie.bif.ost.se:9445/idp/saml</md:OrganizationURL>
+      <md:OrganizationURL xml:lang=""en"">https://idp.maggie.bif.ost.se:9445/idp/saml</md:OrganizationURL>
+    </md:Organization>
+  </md:EntityDescriptor>";
+
+            var entityDescriptor = (ExtendedEntityDescriptor)ExtendedMetadataSerializer.ReaderInstance.ReadMetadata(
+                new MemoryStream(Encoding.UTF8.GetBytes(data)));
+
+            var organizationInfo = entityDescriptor.Organization;
+
+            organizationInfo.Urls.Count.Should().Be(2);
+            organizationInfo.Urls[0].Language.Should().Be(new CultureInfo("en"));
+            organizationInfo.Urls[1].Language.Should().Be(new CultureInfo("da"));
         }
     }
 }

--- a/Kentor.AuthServices/Metadata/ExtendedMetadataSerializer.cs
+++ b/Kentor.AuthServices/Metadata/ExtendedMetadataSerializer.cs
@@ -179,56 +179,14 @@ namespace Kentor.AuthServices.Metadata
 
         protected override ServiceProviderSingleSignOnDescriptor ReadServiceProviderSingleSignOnDescriptor(XmlReader reader)
         {
-            if (reader == null)
-            {
-                throw new ArgumentNullException("reader");
-            }
-
             reader.Skip();
-
             return CreateServiceProviderSingleSignOnDescriptorInstance();
         }
 
         protected override Organization ReadOrganization(XmlReader reader)
         {
-            if (reader == null)
-            {
-                throw new ArgumentNullException("reader");
-            }
-
-            Organization organizationInstance = CreateOrganizationInstance();
-            ReadCustomAttributes(reader, organizationInstance);
-            int num = reader.IsEmptyElement ? 1 : 0;
-            reader.ReadStartElement();
-            if (num == 0)
-            {
-                while (reader.IsStartElement())
-                {
-                    if (reader.IsStartElement("OrganizationName", "urn:oasis:names:tc:SAML:2.0:metadata"))
-                    {
-                        organizationInstance.Names.Add(ReadLocalizedName(reader));
-                    }
-                    else if (reader.IsStartElement("OrganizationDisplayName", "urn:oasis:names:tc:SAML:2.0:metadata"))
-                    {
-                        organizationInstance.DisplayNames.Add(ReadLocalizedName(reader));
-                    }
-                    else if (reader.IsStartElement("OrganizationURL", "urn:oasis:names:tc:SAML:2.0:metadata"))
-                    {
-                        // ensures that no two organization url's with the same language are added
-                        var localizedUri = ReadLocalizedUri(reader);
-                        if (!organizationInstance.Urls.Contains(localizedUri.Language))
-                        {
-                            organizationInstance.Urls.Add(localizedUri);
-                        }
-                    }
-                    else if (!ReadCustomElement(reader, organizationInstance))
-                    {
-                        reader.Skip();
-                    }
-                }
-                reader.ReadEndElement();
-            }
-            return organizationInstance;
+            reader.Skip();
+            return CreateOrganizationInstance();
         }
     }
 }

--- a/Kentor.AuthServices/Metadata/ExtendedMetadataSerializer.cs
+++ b/Kentor.AuthServices/Metadata/ExtendedMetadataSerializer.cs
@@ -177,12 +177,14 @@ namespace Kentor.AuthServices.Metadata
             return new ExtendedEntitiesDescriptor();
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0")]
         protected override ServiceProviderSingleSignOnDescriptor ReadServiceProviderSingleSignOnDescriptor(XmlReader reader)
         {
             reader.Skip();
             return CreateServiceProviderSingleSignOnDescriptorInstance();
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0")]
         protected override Organization ReadOrganization(XmlReader reader)
         {
             reader.Skip();

--- a/Kentor.AuthServices/Metadata/ExtendedMetadataSerializer.cs
+++ b/Kentor.AuthServices/Metadata/ExtendedMetadataSerializer.cs
@@ -176,5 +176,59 @@ namespace Kentor.AuthServices.Metadata
         {
             return new ExtendedEntitiesDescriptor();
         }
+
+        protected override ServiceProviderSingleSignOnDescriptor ReadServiceProviderSingleSignOnDescriptor(XmlReader reader)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException("reader");
+            }
+
+            reader.Skip();
+
+            return CreateServiceProviderSingleSignOnDescriptorInstance();
+        }
+
+        protected override Organization ReadOrganization(XmlReader reader)
+        {
+            if (reader == null)
+            {
+                throw new ArgumentNullException("reader");
+            }
+
+            Organization organizationInstance = CreateOrganizationInstance();
+            ReadCustomAttributes(reader, organizationInstance);
+            int num = reader.IsEmptyElement ? 1 : 0;
+            reader.ReadStartElement();
+            if (num == 0)
+            {
+                while (reader.IsStartElement())
+                {
+                    if (reader.IsStartElement("OrganizationName", "urn:oasis:names:tc:SAML:2.0:metadata"))
+                    {
+                        organizationInstance.Names.Add(ReadLocalizedName(reader));
+                    }
+                    else if (reader.IsStartElement("OrganizationDisplayName", "urn:oasis:names:tc:SAML:2.0:metadata"))
+                    {
+                        organizationInstance.DisplayNames.Add(ReadLocalizedName(reader));
+                    }
+                    else if (reader.IsStartElement("OrganizationURL", "urn:oasis:names:tc:SAML:2.0:metadata"))
+                    {
+                        // ensures that no two organization url's with the same language are added
+                        var localizedUri = ReadLocalizedUri(reader);
+                        if (!organizationInstance.Urls.Contains(localizedUri.Language))
+                        {
+                            organizationInstance.Urls.Add(localizedUri);
+                        }
+                    }
+                    else if (!ReadCustomElement(reader, organizationInstance))
+                    {
+                        reader.Skip();
+                    }
+                }
+                reader.ReadEndElement();
+            }
+            return organizationInstance;
+        }
     }
 }


### PR DESCRIPTION
This PR is in reference to #408.

Includes two fixes, one which completely ignores any information
contained in the `SPSSODescriptor` element, and the other for how
`OrganizationUrl`s are stored.

InCommon seems to have multiple IdP's which contain multiple
organization URL's of the same language. This caused another duplicate
key exception. Added a check before inserting to the URL list that the
specified language doesn't already exist.