### PR TITLE
Want to have the port in the DestinationUrl of the SAML Request send to the Idp.

### DIFF
--- a/Kentor.AuthServices/SAML2P/Saml2RequestBase.cs
+++ b/Kentor.AuthServices/SAML2P/Saml2RequestBase.cs
@@ -102,7 +102,8 @@ namespace Kentor.AuthServices.Saml2P
 
             if (DestinationUrl != null)
             {
-                yield return new XAttribute("Destination", DestinationUrl);
+                //yield return new XAttribute("Destination", DestinationUrl);
+                yield return new XAttribute("Destination", DestinationUrl?.OriginalString);
             }
 
             if (Issuer != null && !string.IsNullOrEmpty(Issuer.Id))


### PR DESCRIPTION
Use DesinationUrl.OriginalString to have the port in the Destinatio of the SAMLRequest sended to the IdP.