### PR TITLE
Correct namepace of Artifact

### DIFF
--- a/Kentor.AuthServices.Tests/Saml2P/Saml2ArtifactResolveTests.cs
+++ b/Kentor.AuthServices.Tests/Saml2P/Saml2ArtifactResolveTests.cs
@@ -34,7 +34,7 @@ namespace Kentor.AuthServices.Tests.Saml2P
     ID = ""_6c3a4f8b9c2d"" Version = ""2.0""
     IssueInstant = ""2004-01-21T19:00:49Z"" >
     <saml2:Issuer>http://sp.example.com</saml2:Issuer>
-    <saml2:Artifact>MyArtifact</saml2:Artifact>
+    <saml2p:Artifact>MyArtifact</saml2p:Artifact>
  </saml2p:ArtifactResolve>");
 
             // Set generated expected values to the actual.

--- a/Kentor.AuthServices/SAML2P/Saml2ArtifactResolve.cs
+++ b/Kentor.AuthServices/SAML2P/Saml2ArtifactResolve.cs
@@ -40,7 +40,7 @@ namespace Kentor.AuthServices.Saml2P
             return new XElement(
                 Saml2Namespaces.Saml2P + "ArtifactResolve",
                 base.ToXNodes(),
-                new XElement(Saml2Namespaces.Saml2 + "Artifact", Artifact))
+                new XElement(Saml2Namespaces.Saml2P + "Artifact", Artifact))
                 .ToString();
         }
     }


### PR DESCRIPTION
Correct namepace of Artifact (samlp:Artifact instead of saml:Artifact) see: https://en.wikipedia.org/wiki/SAML_2.0#Artifact_Resolution_Protocol