### PR TITLE
Added SubjectConfirmationData

### DIFF
--- a/Kentor.AuthServices.Tests/Saml2AssertionExtensionsTests.cs
+++ b/Kentor.AuthServices.Tests/Saml2AssertionExtensionsTests.cs
@@ -73,6 +73,35 @@ namespace Kentor.AuthServices.Tests
         }
 
         [TestMethod]
+        public void Saml2AssertionExtensions_ToXElement_Subject_ConfirmationData()
+        {
+            var subjectName = "JohnDoe";
+            var destination = new Uri("http://sp.example.com");
+            var inResponseTo = new Saml2Id("abc123");
+
+            var assertion = new Saml2Assertion(
+                new Saml2NameIdentifier("http://idp.example.com"))
+            {
+                Subject = new Saml2Subject(new Saml2NameIdentifier(subjectName))
+            };
+
+            var subject = assertion.ToXElement(destination, inResponseTo);
+
+            subject.Element(Saml2Namespaces.Saml2 + "Subject").
+                Element(Saml2Namespaces.Saml2 + "NameID").Value.Should().Be(subjectName);
+
+            subject.Element(Saml2Namespaces.Saml2 + "Subject").
+                Element(Saml2Namespaces.Saml2 + "SubjectConfirmation").
+                Element(Saml2Namespaces.Saml2 + "SubjectConfirmationData").
+                Attribute("Recipient").Value.Should().Be(destination.AbsoluteUri);
+
+            subject.Element(Saml2Namespaces.Saml2 + "Subject").
+                Element(Saml2Namespaces.Saml2 + "SubjectConfirmation").
+                Element(Saml2Namespaces.Saml2 + "SubjectConfirmationData").
+                Attribute("InResponseTo").Value.Should().Be(inResponseTo.Value);
+        }
+
+        [TestMethod]
         public void Saml2AssertionExtensions_ToXElement_Conditions()
         {
             var assertion = new Saml2Assertion(

--- a/Kentor.AuthServices.Tests/Saml2AssertionExtensionsTests.cs
+++ b/Kentor.AuthServices.Tests/Saml2AssertionExtensionsTests.cs
@@ -73,31 +73,45 @@ namespace Kentor.AuthServices.Tests
         }
 
         [TestMethod]
-        public void Saml2AssertionExtensions_ToXElement_Subject_ConfirmationData()
+        public void Saml2AssertionExtensions_ToXElement_SubjectConfirmationData()
         {
             var subjectName = "JohnDoe";
             var destination = new Uri("http://sp.example.com");
             var inResponseTo = new Saml2Id("abc123");
+            var notOnOrAfter = DateTime.UtcNow.AddMinutes(2);
 
             var assertion = new Saml2Assertion(
                 new Saml2NameIdentifier("http://idp.example.com"))
             {
                 Subject = new Saml2Subject(new Saml2NameIdentifier(subjectName))
+                {
+                    SubjectConfirmations =
+                    {
+                        new Saml2SubjectConfirmation(
+                        new Uri("urn:oasis:names:tc:SAML:2.0:cm:bearer"),
+                        new Saml2SubjectConfirmationData
+                        {
+                            NotOnOrAfter = notOnOrAfter,
+                            InResponseTo = inResponseTo,
+                            Recipient = destination
+                        })
+                    }
+                }
             };
 
-            var subject = assertion.ToXElement(destination, inResponseTo);
+            var subject = assertion.ToXElement();
 
-            subject.Element(Saml2Namespaces.Saml2 + "Subject").
-                Element(Saml2Namespaces.Saml2 + "NameID").Value.Should().Be(subjectName);
-
-            subject.Element(Saml2Namespaces.Saml2 + "Subject").
+            var confirmationData = subject.Element(Saml2Namespaces.Saml2 + "Subject").
                 Element(Saml2Namespaces.Saml2 + "SubjectConfirmation").
-                Element(Saml2Namespaces.Saml2 + "SubjectConfirmationData").
-                Attribute("Recipient").Value.Should().Be(destination.AbsoluteUri);
+                Element(Saml2Namespaces.Saml2 + "SubjectConfirmationData");
 
-            subject.Element(Saml2Namespaces.Saml2 + "Subject").
-                Element(Saml2Namespaces.Saml2 + "SubjectConfirmation").
-                Element(Saml2Namespaces.Saml2 + "SubjectConfirmationData").
+            confirmationData.
+                Attribute("Recipient").Value.Should().Be(destination.OriginalString);
+
+            confirmationData.
+                Attribute("NotOnOrAfter").Value.Should().Be(notOnOrAfter.ToSaml2DateTimeString());
+
+            confirmationData.
                 Attribute("InResponseTo").Value.Should().Be(inResponseTo.Value);
         }
 

--- a/Kentor.AuthServices.Tests/Saml2SubjectExtensionsTests.cs
+++ b/Kentor.AuthServices.Tests/Saml2SubjectExtensionsTests.cs
@@ -33,5 +33,57 @@ namespace Kentor.AuthServices.Tests
             subject.Element(Saml2Namespaces.Saml2 + "SubjectConfirmation")
                 .Attribute("Method").Value.Should().Be("urn:oasis:names:tc:SAML:2.0:cm:bearer");
         }
+
+        [TestMethod]
+        public void Saml2SubjectExtensions_ToXElement_SubjectConfirmation_CheckNull()
+        {
+            Saml2SubjectConfirmation saml2SubjectConfirmation = null;
+
+            Action a = () => saml2SubjectConfirmation.ToXElement();
+
+            a.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("subjectConfirmation");
+        }
+
+        [TestMethod]
+        public void Saml2SubjectExtensions_ToXElement_SubjectConfirmation()
+        {
+            var saml2SubjectConfirmation = new Saml2SubjectConfirmation(new Uri("urn:oasis:names:tc:SAML:2.0:cm:bearer"));
+
+            var confirmation = saml2SubjectConfirmation.ToXElement();
+
+            confirmation.Attribute("Method").Value.Should().Be("urn:oasis:names:tc:SAML:2.0:cm:bearer");
+        }
+
+        [TestMethod]
+        public void Saml2SubjectExtensions_ToXElement_SubjectConfirmationData_CheckNull()
+        {
+            Saml2SubjectConfirmationData saml2SubjectConfirmationData = null;
+
+            Action a = () => saml2SubjectConfirmationData.ToXElement();
+
+            a.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("subjectConfirmationData");
+        }
+
+        [TestMethod]
+        public void Saml2SubjectExtensions_ToXElement_SubjectConfirmationData()
+        {
+            var destination = new Uri("http://sp.example.com");
+            var inResponseTo = new Saml2Id("abc123");
+            var notOnOrAfter = DateTime.UtcNow.AddMinutes(2);
+            var saml2SubjectConfirmationData = new Saml2SubjectConfirmationData
+            {
+                NotOnOrAfter = notOnOrAfter,
+                InResponseTo = inResponseTo,
+                Recipient = destination
+            };
+
+            var confirmation = saml2SubjectConfirmationData.ToXElement();
+
+            confirmation.Attribute("NotOnOrAfter").Value.Should().Be(notOnOrAfter.ToSaml2DateTimeString());
+
+            confirmation.Attribute("Recipient").Value.Should().Be(destination.OriginalString);
+
+            confirmation.Attribute("InResponseTo").Value.Should().Be(inResponseTo.Value);
+        }
     }
 }

--- a/Kentor.AuthServices.Tests/Saml2SubjectExtensionsTests.cs
+++ b/Kentor.AuthServices.Tests/Saml2SubjectExtensionsTests.cs
@@ -70,16 +70,21 @@ namespace Kentor.AuthServices.Tests
             var destination = new Uri("http://sp.example.com");
             var inResponseTo = new Saml2Id("abc123");
             var notOnOrAfter = DateTime.UtcNow.AddMinutes(2);
+            var notBefore = DateTime.UtcNow;
+
             var saml2SubjectConfirmationData = new Saml2SubjectConfirmationData
             {
                 NotOnOrAfter = notOnOrAfter,
                 InResponseTo = inResponseTo,
-                Recipient = destination
+                Recipient = destination,
+                NotBefore = notBefore
             };
 
             var confirmation = saml2SubjectConfirmationData.ToXElement();
 
             confirmation.Attribute("NotOnOrAfter").Value.Should().Be(notOnOrAfter.ToSaml2DateTimeString());
+
+            confirmation.Attribute("NotBefore").Value.Should().Be(notBefore.ToSaml2DateTimeString());
 
             confirmation.Attribute("Recipient").Value.Should().Be(destination.OriginalString);
 

--- a/Kentor.AuthServices/ClaimsIdentityExtensions.cs
+++ b/Kentor.AuthServices/ClaimsIdentityExtensions.cs
@@ -34,6 +34,26 @@ namespace Kentor.AuthServices
             EntityId issuer,
             Uri audience)
         {
+            return ToSaml2Assertion(identity, issuer, audience, null, null);
+        }
+
+        /// <summary>
+        /// Creates a Saml2Assertion from a ClaimsIdentity.
+        /// </summary>
+        /// <param name="identity">Claims to include in Assertion.</param>
+        /// <param name="issuer">Issuer to include in assertion.</param>
+        /// <param name="audience">Audience to set as audience restriction.</param>
+        /// <param name="inResponseTo">In response to id</param>
+        /// <param name="destinationUri">The destination Uri for the message</param>
+        /// <returns>Saml2Assertion</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static Saml2Assertion ToSaml2Assertion(
+            this ClaimsIdentity identity,
+            EntityId issuer,
+            Uri audience,
+            Saml2Id inResponseTo,
+            Uri destinationUri)
+        {
             if (identity == null)
             {
                 throw new ArgumentNullException(nameof(identity));
@@ -44,10 +64,7 @@ namespace Kentor.AuthServices
                 throw new ArgumentNullException(nameof(issuer));
             }
 
-            var assertion = new Saml2Assertion(new Saml2NameIdentifier(issuer.Id))
-            {
-                Subject = new Saml2Subject(identity.ToSaml2NameIdentifier()),
-            };
+            var assertion = new Saml2Assertion(new Saml2NameIdentifier(issuer.Id));
 
             assertion.Statements.Add(
                 new Saml2AuthenticationStatement(
@@ -60,7 +77,8 @@ namespace Kentor.AuthServices
 
             var attributeClaims = identity.Claims.Where(
                 c => c.Type != ClaimTypes.NameIdentifier
-                && c.Type != AuthServicesClaimTypes.SessionIndex).GroupBy(c => c.Type);
+                && c.Type != AuthServicesClaimTypes.SessionIndex).GroupBy(c => c.Type)
+                .ToArray();
 
             if (attributeClaims.Any())
             {
@@ -70,9 +88,26 @@ namespace Kentor.AuthServices
                             ac => new Saml2Attribute(ac.Key, ac.Select(c => c.Value)))));
             }
 
+            var notOnOrAfter = DateTime.UtcNow.AddMinutes(2);
+
+            assertion.Subject = new Saml2Subject(identity.ToSaml2NameIdentifier())
+            {
+                SubjectConfirmations =
+                {
+                    new Saml2SubjectConfirmation(
+                        new Uri("urn:oasis:names:tc:SAML:2.0:cm:bearer"),
+                        new Saml2SubjectConfirmationData
+                        {
+                            NotOnOrAfter = notOnOrAfter,
+                            InResponseTo = inResponseTo,
+                            Recipient = destinationUri
+                        })
+                }
+            };
+
             assertion.Conditions = new Saml2Conditions()
             {
-                NotOnOrAfter = DateTime.UtcNow.AddMinutes(2)
+                NotOnOrAfter = notOnOrAfter
             };
 
             if (audience != null)

--- a/Kentor.AuthServices/SAML2P/Saml2Response.cs
+++ b/Kentor.AuthServices/SAML2P/Saml2Response.cs
@@ -296,7 +296,8 @@ namespace Kentor.AuthServices.Saml2P
             foreach (var ci in claimsIdentities)
             {
                 responseElement.AppendChild(xml.ReadNode(
-                    ci.ToSaml2Assertion(Issuer, audience).ToXElement().CreateReader()));
+                    ci.ToSaml2Assertion(Issuer, audience)
+                        .ToXElement(DestinationUrl, InResponseTo).CreateReader()));
             }
 
             xmlElement = xml.DocumentElement;

--- a/Kentor.AuthServices/SAML2P/Saml2Response.cs
+++ b/Kentor.AuthServices/SAML2P/Saml2Response.cs
@@ -296,8 +296,7 @@ namespace Kentor.AuthServices.Saml2P
             foreach (var ci in claimsIdentities)
             {
                 responseElement.AppendChild(xml.ReadNode(
-                    ci.ToSaml2Assertion(Issuer, audience)
-                        .ToXElement(DestinationUrl, InResponseTo).CreateReader()));
+                    ci.ToSaml2Assertion(Issuer, audience, InResponseTo, DestinationUrl).ToXElement().CreateReader()));
             }
 
             xmlElement = xml.DocumentElement;

--- a/Kentor.AuthServices/Saml2AssertionExtensions.cs
+++ b/Kentor.AuthServices/Saml2AssertionExtensions.cs
@@ -19,18 +19,6 @@ namespace Kentor.AuthServices
         /// <returns>XElement</returns>
         public static XElement ToXElement(this Saml2Assertion assertion)
         {
-            return ToXElement(assertion, null, null);
-        }
-
-        /// <summary>
-        /// Writes out the assertion as an XElement.
-        /// </summary>
-        /// <param name="assertion">The assertion to create xml for.</param>
-        /// <param name="destination">The destination to create xml for.</param>
-        /// <param name="inResponseTo">The request ID.</param>
-        /// <returns>XElement</returns>
-        public static XElement ToXElement(this Saml2Assertion assertion, Uri destination, Saml2Id inResponseTo)
-        {
             if(assertion == null)
             {
                 throw new ArgumentNullException(nameof(assertion));
@@ -46,7 +34,7 @@ namespace Kentor.AuthServices
 
             if (assertion.Subject != null)
             {
-                xml.Add(assertion.Subject.ToXElement(destination, inResponseTo));
+                xml.Add(assertion.Subject.ToXElement());
             }
 
             if(assertion.Conditions != null)

--- a/Kentor.AuthServices/Saml2AssertionExtensions.cs
+++ b/Kentor.AuthServices/Saml2AssertionExtensions.cs
@@ -19,6 +19,18 @@ namespace Kentor.AuthServices
         /// <returns>XElement</returns>
         public static XElement ToXElement(this Saml2Assertion assertion)
         {
+            return ToXElement(assertion, null, null);
+        }
+
+        /// <summary>
+        /// Writes out the assertion as an XElement.
+        /// </summary>
+        /// <param name="assertion">The assertion to create xml for.</param>
+        /// <param name="destination">The destination to create xml for.</param>
+        /// <param name="inResponseTo">The request ID.</param>
+        /// <returns>XElement</returns>
+        public static XElement ToXElement(this Saml2Assertion assertion, Uri destination, Saml2Id inResponseTo)
+        {
             if(assertion == null)
             {
                 throw new ArgumentNullException(nameof(assertion));
@@ -34,7 +46,7 @@ namespace Kentor.AuthServices
 
             if (assertion.Subject != null)
             {
-                xml.Add(assertion.Subject.ToXElement());
+                xml.Add(assertion.Subject.ToXElement(destination, inResponseTo));
             }
 
             if(assertion.Conditions != null)

--- a/Kentor.AuthServices/Saml2SubjectExtensions.cs
+++ b/Kentor.AuthServices/Saml2SubjectExtensions.cs
@@ -20,15 +20,40 @@ namespace Kentor.AuthServices
         /// <returns>XElement</returns>
         public static XElement ToXElement(this Saml2Subject subject)
         {
-            if(subject == null)
+            return ToXElement(subject, null, null);
+        }
+
+        /// <summary>
+        /// Writes out the subject as an XElement.
+        /// </summary>
+        /// <param name="subject">The subject to create xml for.</param>
+        /// <param name="destination">The destination to create xml for.</param>
+        /// <param name="inResponseTo">The request ID.</param>
+        /// <returns>XElement</returns>
+        public static XElement ToXElement(this Saml2Subject subject, Uri destination, Saml2Id inResponseTo)
+        {
+            if (subject == null)
             {
                 throw new ArgumentNullException(nameof(subject));
+            }
+
+            var confirmationData = new XElement(Saml2Namespaces.Saml2 + "SubjectConfirmationData",
+                        new XAttribute("NotOnOrAfter",
+                            DateTime.UtcNow.AddMinutes(2).ToSaml2DateTimeString()));
+            if (destination != null)
+            {
+                confirmationData.SetAttributeValue("Recipient", destination.AbsoluteUri);
+            }
+            if (inResponseTo != null)
+            {
+                confirmationData.SetAttributeValue("InResponseTo", inResponseTo);
             }
 
             return new XElement(Saml2Namespaces.Saml2 + "Subject",
                 subject.NameId.ToXElement(),
                 new XElement(Saml2Namespaces.Saml2 + "SubjectConfirmation",
-                    new XAttribute("Method", "urn:oasis:names:tc:SAML:2.0:cm:bearer"))
+                    new XAttribute("Method", "urn:oasis:names:tc:SAML:2.0:cm:bearer"),
+                    confirmationData)
                 );
         }
     }

--- a/Kentor.AuthServices/Saml2SubjectExtensions.cs
+++ b/Kentor.AuthServices/Saml2SubjectExtensions.cs
@@ -24,12 +24,17 @@ namespace Kentor.AuthServices
             var element = new XElement(Saml2Namespaces.Saml2 + "Subject",
                 subject.NameId.ToXElement());
 
-            if (subject.SubjectConfirmations != null)
+            foreach (var subjectConfirmation in subject.SubjectConfirmations)
             {
-                foreach (var subjectConfirmation in subject.SubjectConfirmations)
-                {
-                    element.Add(subjectConfirmation.ToXElement());
-                }
+                element.Add(subjectConfirmation.ToXElement());
+            }
+
+            if (subject.SubjectConfirmations.Count == 0)
+            {
+                // Although SubjectConfirmation is optional in the SAML core spec, it is
+                // mandatory in the Web Browser SSO Profile and must have a value of bearer.
+                element.Add(new Saml2SubjectConfirmation(
+                    new Uri("urn:oasis:names:tc:SAML:2.0:cm:bearer")).ToXElement());
             }
 
             return element;
@@ -76,7 +81,7 @@ namespace Kentor.AuthServices
 
             if (subjectConfirmationData.NotOnOrAfter.HasValue)
             {
-                element.SetAttributeValue("NotOnOrAfter", 
+                element.SetAttributeValue("NotOnOrAfter",
                     subjectConfirmationData.NotOnOrAfter.Value.ToSaml2DateTimeString());
             }
 


### PR DESCRIPTION
Fixes #461 

This pull request adds SubjectConfirmationData to the saml response token as defined in [the specification](http://docs.oasis-open.org/imi/identity/cs/imi-saml2.0-profile-cs-01.html#_Ref248548678).
The missing confirmation data was causing SAML tokens to fail validation.