### PR TITLE
Moved MetadataRefreshScheduler to Metadata directory,  #167

### DIFF
--- a/Kentor.AuthServices.Tests/Kentor.AuthServices.Tests.csproj
+++ b/Kentor.AuthServices.Tests/Kentor.AuthServices.Tests.csproj
@@ -199,7 +199,7 @@
     <Compile Include="StubFactory.cs" />
     <Compile Include="WebSSO\AuthServicesUrlsTests.cs" />
     <Compile Include="Configuration\KentorAuthServicesSectionTests.cs" />
-    <Compile Include="MetadataRefreshSchedulerTests.cs" />
+    <Compile Include="Metadata\MetadataRefreshSchedulerTests.cs" />
     <Compile Include="Internal\XmlHelpersTests.cs" />
     <Compile Include="WebSSO\LogoutCommandTests.cs" />
     <Compile Include="WebSSO\StubSaml2Binding.cs" />

--- a/Kentor.AuthServices.Tests/Metadata/MetadataRefreshSchedulerTests.cs
+++ b/Kentor.AuthServices.Tests/Metadata/MetadataRefreshSchedulerTests.cs
@@ -2,8 +2,9 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using FluentAssertions;
 using NSubstitute;
+using Kentor.AuthServices.Metadata;
 
-namespace Kentor.AuthServices.Tests
+namespace Kentor.AuthServices.Tests.Metadata
 {
     [TestClass]
     public class MetadataRefreshSchedulerTests

--- a/Kentor.AuthServices/Kentor.AuthServices.csproj
+++ b/Kentor.AuthServices/Kentor.AuthServices.csproj
@@ -101,7 +101,7 @@
     <Compile Include="Metadata\RequestedAttribute.cs" />
     <Compile Include="Metadata\ExtendedEntitiesDescriptor.cs" />
     <Compile Include="ICachedMetadata.cs" />
-    <Compile Include="MetadataRefreshScheduler.cs" />
+    <Compile Include="Metadata\MetadataRefreshScheduler.cs" />
     <Compile Include="Metadata\ServiceProviderSingleSignOnDescriptorExtensions.cs" />
     <Compile Include="Metadata\ExtendedEntityDescriptor.cs" />
     <Compile Include="Exceptions\AuthServicesException.cs" />
@@ -174,7 +174,6 @@
       <link>CustomDictionary.xml</link>
     </CodeAnalysisDictionary>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Kentor.AuthServices/Metadata/MetadataRefreshScheduler.cs
+++ b/Kentor.AuthServices/Metadata/MetadataRefreshScheduler.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Kentor.AuthServices
+namespace Kentor.AuthServices.Metadata
 {
     internal static class MetadataRefreshScheduler
     {


### PR DESCRIPTION
Fixes #167

Moved MetadataRefreshScheduler to Metadata directory and updated namespace. Did the same for corresponding unit test.