### PR TITLE
Logout command users HttpRequestData.User

### DIFF
--- a/Kentor.AuthServices.HttpModule/HttpRequestBaseExtensions.cs
+++ b/Kentor.AuthServices.HttpModule/HttpRequestBaseExtensions.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web;
@@ -54,7 +55,8 @@ namespace Kentor.AuthServices.HttpModule
                 requestBase.Form.Cast<string>().Select((de, i) =>
                     new KeyValuePair<string, string[]>(de, ((string)requestBase.Form[i]).Split(','))),
                 cookies,
-                v => MachineKey.Unprotect(v, ProtectionPurpose));
+                v => MachineKey.Unprotect(v, ProtectionPurpose),
+                ClaimsPrincipal.Current);
         }
 
         private static IEnumerable<KeyValuePair<string, string>> GetCookies(HttpRequestBase requestBase)

--- a/Kentor.AuthServices.Owin/OwinContextExtensions.cs
+++ b/Kentor.AuthServices.Owin/OwinContextExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -40,7 +41,8 @@ namespace Kentor.AuthServices.Owin
                 applicationRootPath,
                 formData,
                 context.Request.Cookies,
-                cookieDecryptor);
+                cookieDecryptor,
+                context.Request.User as ClaimsPrincipal);
         }
     }
 }

--- a/Kentor.AuthServices.Tests/HttpModule/HttpRequestBaseExtensionsTests.cs
+++ b/Kentor.AuthServices.Tests/HttpModule/HttpRequestBaseExtensionsTests.cs
@@ -10,6 +10,7 @@ using System.Web.Security;
 using System.Text;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 
 namespace Kentor.AuthServices.Tests.HttpModule
 {
@@ -55,7 +56,8 @@ namespace Kentor.AuthServices.Tests.HttpModule
                     new KeyValuePair<string, string[]>("Key", new string[] { "Value" })
                 },
                 Enumerable.Empty<KeyValuePair<string, string>>(),
-                null);
+                null, 
+                ClaimsPrincipal.Current);
 
             actual.ShouldBeEquivalentTo(expected, opt => opt.Excluding(s => s.StoredRequestState));
             actual.StoredRequestState.ReturnUrl.AbsoluteUri.Should().Be("urn:someUri");
@@ -88,7 +90,8 @@ namespace Kentor.AuthServices.Tests.HttpModule
                     new KeyValuePair<string, string[]>("Key", new string[] { "Value" })
                 },
                 Enumerable.Empty<KeyValuePair<string, string>>(),
-                null);
+                null,
+                ClaimsPrincipal.Current);
 
             subject.ShouldBeEquivalentTo(expected);
         }

--- a/Kentor.AuthServices.Tests/Owin/KentorAuthServicesAuthenticationMiddlewareTests.cs
+++ b/Kentor.AuthServices.Tests/Owin/KentorAuthServicesAuthenticationMiddlewareTests.cs
@@ -225,8 +225,7 @@ namespace Kentor.AuthServices.Tests.Owin
             context.Request.Host = new HostString("sp-internal.example.com");
             context.Request.PathBase = new PathString("/InternalPath");
             context.Request.Path = new PathString("/LoggedOut");
-
-            Thread.CurrentPrincipal = new ClaimsPrincipal(
+            context.Request.User = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
                     new Claim(ClaimTypes.NameIdentifier, "NameId", null, "https://idp.example.com"),
@@ -268,8 +267,7 @@ namespace Kentor.AuthServices.Tests.Owin
             context.Request.Host = new HostString("sp-internal.example.com");
             context.Request.PathBase = new PathString("/InternalPath");
             context.Request.Path = new PathString("/LoggedOut");
-
-            Thread.CurrentPrincipal = new ClaimsPrincipal(
+            context.Request.User = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
                     new Claim(ClaimTypes.NameIdentifier, "NameId", null, "https://idp.example.com"),
@@ -337,8 +335,7 @@ namespace Kentor.AuthServices.Tests.Owin
             context.Request.PathBase = new PathString("/AppPath");
             context.Request.Path = new PathString(path);
             context.Response.Headers["Location"] = location;
-
-            Thread.CurrentPrincipal = new ClaimsPrincipal(
+            context.Request.User = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
                     new Claim(ClaimTypes.NameIdentifier, "NameId", null, "https://idp.example.com"),
@@ -374,8 +371,7 @@ namespace Kentor.AuthServices.Tests.Owin
 
             var context = OwinTestHelpers.CreateOwinContext();
             context.Response.Headers["Location"] = "http://sp.example.com/locationHeader";
-
-            Thread.CurrentPrincipal = new ClaimsPrincipal(
+            context.Request.User = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
                     new Claim(ClaimTypes.NameIdentifier, "NameId", null, "https://idp.example.com"),
@@ -431,7 +427,7 @@ namespace Kentor.AuthServices.Tests.Owin
 
             var context = OwinTestHelpers.CreateOwinContext();
 
-            Thread.CurrentPrincipal = new ClaimsPrincipal(
+            context.Request.User = new ClaimsPrincipal(
                 new ClaimsIdentity(new Claim[]
                 {
                     new Claim(ClaimTypes.NameIdentifier, "NameId", null, "https://idp.example.com"),

--- a/Kentor.AuthServices/IdentityProvider.cs
+++ b/Kentor.AuthServices/IdentityProvider.cs
@@ -483,8 +483,9 @@ namespace Kentor.AuthServices
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ServiceCertificates")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA2204:Literals should be spelled correctly", MessageId = "ISPOptions")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "Logout")]
-        public Saml2LogoutRequest CreateLogoutRequest()
+        public Saml2LogoutRequest CreateLogoutRequest(ClaimsPrincipal user)
         {
+            if (user == null) throw new ArgumentNullException(nameof(user));
             if (spOptions.SigningServiceCertificate == null)
             {
                 throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
@@ -496,11 +497,11 @@ namespace Kentor.AuthServices
             {
                 DestinationUrl = SingleLogoutServiceUrl,
                 Issuer = spOptions.EntityId,
-                NameId = (ClaimsPrincipal.Current.FindFirst(AuthServicesClaimTypes.LogoutNameIdentifier)
-                            ?? ClaimsPrincipal.Current.FindFirst(ClaimTypes.NameIdentifier))
+                NameId = (user.FindFirst(AuthServicesClaimTypes.LogoutNameIdentifier)
+                            ?? user.FindFirst(ClaimTypes.NameIdentifier))
                             .ToSaml2NameIdentifier(),
                 SessionIndex =
-                    ClaimsPrincipal.Current.FindFirst(AuthServicesClaimTypes.SessionIndex).Value,
+                    user.FindFirst(AuthServicesClaimTypes.SessionIndex).Value,
                 SigningCertificate = spOptions.SigningServiceCertificate,
             };
         }

--- a/Kentor.AuthServices/WebSSO/HttpRequestData.cs
+++ b/Kentor.AuthServices/WebSSO/HttpRequestData.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web;
+using System.Security.Claims;
 
 namespace Kentor.AuthServices.WebSso
 {
@@ -35,15 +36,40 @@ namespace Kentor.AuthServices.WebSso
             string applicationPath,
             IEnumerable<KeyValuePair<string, string[]>> formData,
             IEnumerable<KeyValuePair<string, string>> cookies,
-            Func<byte[], byte[]> cookieDecryptor)
+            Func<byte[], byte[]> cookieDecryptor) : this(httpMethod, url, applicationPath, formData, cookies, cookieDecryptor, user: null)
         {
-            Init(httpMethod, url, applicationPath, formData, cookies, cookieDecryptor);
+            // empty
+        }
+
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="httpMethod">Http method of the request</param>
+        /// <param name="url">Full url requested</param>
+        /// <param name="formData">Form data, if present (only for POST requests)</param>
+        /// <param name="applicationPath">Path to the application root</param>
+        /// <param name="cookies">Cookies of request</param>
+        /// <param name="cookieDecryptor">Function that decrypts cookie
+        /// contents to clear text.</param>
+        /// <param name="user">Claims Principal associated with the request
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Decryptor")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
+        public HttpRequestData(
+            string httpMethod,
+            Uri url,
+            string applicationPath,
+            IEnumerable<KeyValuePair<string, string[]>> formData,
+            IEnumerable<KeyValuePair<string, string>> cookies,
+            Func<byte[], byte[]> cookieDecryptor,
+            ClaimsPrincipal user)
+        {
+            Init(httpMethod, url, applicationPath, formData, cookies, cookieDecryptor, user);
         }
 
         // Used by tests.
         internal HttpRequestData(string httpMethod, Uri url)
         {
-            Init(httpMethod, url, "/", null, Enumerable.Empty<KeyValuePair<string, string>>(), null);
+            Init(httpMethod, url, "/", null, Enumerable.Empty<KeyValuePair<string, string>>(), null, null);
         }
 
         // Used by tests.
@@ -64,9 +90,11 @@ namespace Kentor.AuthServices.WebSso
             string applicationPath,
             IEnumerable<KeyValuePair<string, string[]>> formData,
             IEnumerable<KeyValuePair<string, string>> cookies,
-            Func<byte[], byte[]> cookieDecryptor)
+            Func<byte[], byte[]> cookieDecryptor,
+            ClaimsPrincipal user)
         {
             InitBasicFields(httpMethod, url, applicationPath, formData);
+            User = user;
 
             var relayState = QueryString["RelayState"].SingleOrDefault();
             if(relayState == null)
@@ -131,33 +159,38 @@ namespace Kentor.AuthServices.WebSso
         /// <summary>
         /// The http method of the request.
         /// </summary>
-        public string HttpMethod { get; private set; }
+        public string HttpMethod { get; set; }
 
         /// <summary>
         /// The complete Url of the request.
         /// </summary>
-        public Uri Url { get; private set; }
+        public Uri Url { get; set; }
 
         /// <summary>
         /// The form data associated with the request (if any).
         /// </summary>
-        public IReadOnlyDictionary<string, string> Form { get; private set; }
+        public IReadOnlyDictionary<string, string> Form { get; set; }
 
         /// <summary>
         /// The query string parameters of the request.
         /// </summary>
-        public ILookup<String, String> QueryString { get; private set; }
+        public ILookup<String, String> QueryString { get; set; }
 
         /// <summary>
         /// The root Url of the application. This includes the virtual directory
         /// that the application is installed in, e.g. http://hosting.example.com/myapp/
         /// </summary>
-        public Uri ApplicationUrl { get; private set; }
+        public Uri ApplicationUrl { get; set; }
 
 
         /// <summary>
         /// Request state from a previous call, carried over through cookie.
         /// </summary>
-        public StoredRequestState StoredRequestState { get; private set; }
+        public StoredRequestState StoredRequestState { get; set; }
+
+        /// <summary>
+        /// User (if any) associated with the request
+        /// </summary>
+        public ClaimsPrincipal User { get; set; }
     }
 }


### PR DESCRIPTION
Fixes #483

BREAKING CHANGE to `IdentityProvider.CreateLogoutRequest` (now requires a ClaimsPrincipal)