### PR TITLE
Default path if stored request state lost during SLO

### DIFF
--- a/Kentor.AuthServices/WebSSO/LogOutCommand.cs
+++ b/Kentor.AuthServices/WebSSO/LogOutCommand.cs
@@ -66,6 +66,7 @@ namespace Kentor.AuthServices.WebSso
             }
 
             CommandResult commandResult;
+            var returnUrl = GetReturnUrl(request, returnPath, options);
             var binding = options.Notifications.GetBinding(request);
             if (binding != null)
             {
@@ -77,7 +78,7 @@ namespace Kentor.AuthServices.WebSso
                         commandResult = HandleRequest(unbindResult, options);
                         break;
                     case "LogoutResponse":
-                        commandResult = HandleResponse(unbindResult, request);
+                        commandResult = HandleResponse(unbindResult, request, returnUrl);
                         break;
                     default:
                         throw new NotImplementedException();
@@ -85,7 +86,7 @@ namespace Kentor.AuthServices.WebSso
             }
             else
             {
-                commandResult = InitiateLogout(request, returnPath, options);
+                commandResult = InitiateLogout(request, returnUrl, options);
             }
             options.Notifications.LogoutCommandResultCreated(commandResult);
             return commandResult;
@@ -113,7 +114,7 @@ namespace Kentor.AuthServices.WebSso
             }
         }
 
-        private static CommandResult InitiateLogout(HttpRequestData request, string returnPath, IOptions options)
+        private static CommandResult InitiateLogout(HttpRequestData request, Uri returnUrl, IOptions options)
         {
             string idpEntityId = null;
             Claim sessionIndexClaim = null;
@@ -139,7 +140,7 @@ namespace Kentor.AuthServices.WebSso
 
                 commandResult.RequestState = new StoredRequestState(
                     idp.EntityId,
-                    GetReturnUrl(request, returnPath, options),
+                    returnUrl,
                     logoutRequest.Id,
                     null);
 
@@ -150,7 +151,7 @@ namespace Kentor.AuthServices.WebSso
                 commandResult = new CommandResult
                 {
                     HttpStatusCode = HttpStatusCode.SeeOther,
-                    Location = GetReturnUrl(request, returnPath, options)
+                    Location = returnUrl
                 };
             }
 
@@ -201,7 +202,7 @@ namespace Kentor.AuthServices.WebSso
             return result;
         }
 
-        private static CommandResult HandleResponse(UnbindResult unbindResult, HttpRequestData request)
+        private static CommandResult HandleResponse(UnbindResult unbindResult, HttpRequestData request, Uri returnUrl)
         {
             var status = Saml2LogoutResponse.FromXml(unbindResult.Data).Status;
             if(status != Saml2StatusCode.Success)
@@ -214,7 +215,7 @@ namespace Kentor.AuthServices.WebSso
             return new CommandResult()
             {
                 HttpStatusCode = HttpStatusCode.SeeOther,
-                Location = request.StoredRequestState.ReturnUrl,
+                Location = request.StoredRequestState?.ReturnUrl ?? returnUrl,
                 ClearCookieName = "Kentor." + unbindResult.RelayState
             };
         }


### PR DESCRIPTION
Fixes #509

Uses application path as default in the basic case, or returnPath if it was specified in LogoutCommand.Run

Not 100% sure this is the right approach but thought it was easier to discuss actual code rather than ideas about code.