### PR TITLE
More informative message for malformed Destination

### DIFF
--- a/Kentor.AuthServices.Tests/Saml2P/Saml2ResponseTests.cs
+++ b/Kentor.AuthServices.Tests/Saml2P/Saml2ResponseTests.cs
@@ -100,6 +100,28 @@ namespace Kentor.AuthServices.Tests.Saml2P
         }
 
         [TestMethod]
+        public void Saml2Response_Read_ThrowsOnMalformedDestination()
+        {
+            var response =
+            @"<saml2p:Response xmlns:saml2p=""urn:oasis:names:tc:SAML:2.0:protocol""
+            xmlns:saml2=""urn:oasis:names:tc:SAML:2.0:assertion""
+            Destination = ""not_a_uri""
+            ID = """ + MethodBase.GetCurrentMethod().Name + @""" Version=""2.0"" IssueInstant=""2013-01-01T00:00:00Z"">
+            <saml2:Issuer>
+                https://some.issuer.example.com
+            </saml2:Issuer>
+                <saml2p:Status>
+                    <saml2p:StatusCode Value=""urn:oasis:names:tc:SAML:2.0:status:Requester"" />
+                </saml2p:Status>
+            </saml2p:Response>";
+
+            Action a = () => Saml2Response.Read(response);
+
+            a.ShouldThrow<BadFormatSamlResponseException>()
+                .WithMessage("Destination value was not a valid Uri");
+        }
+
+        [TestMethod]
         public void Saml2Response_Read_Issuer()
         {
             var response =

--- a/Kentor.AuthServices/SAML2P/Saml2Response.cs
+++ b/Kentor.AuthServices/SAML2P/Saml2Response.cs
@@ -105,7 +105,12 @@ namespace Kentor.AuthServices.Saml2P
 
             if (destinationUrlString != null)
             {
-                DestinationUrl = new Uri(destinationUrlString);
+                Uri parsedDestination;
+                if (!Uri.TryCreate(destinationUrlString, UriKind.Absolute, out parsedDestination))
+                {
+                    throw new BadFormatSamlResponseException("Destination value was not a valid Uri");
+                }
+                DestinationUrl = parsedDestination;
             }
         }
 


### PR DESCRIPTION
Throw an informative message when the Destination is not a valid Uri. Previously the exception was `UriFormatException` and it was not clear which property was malformed.