### PR TITLE
Include serviceCertificate in the example configuration

### DIFF
--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -71,6 +71,11 @@ read web.config, but can also be configured from code.
          allowUnsolicitedAuthnResponse="true" 
          loadMetadata = "true" />
   </identityProviders>
+  <!-- Optional configuration for signed requests. Required for Single Logout. -->
+  <serviceCertificates>
+    <add fileName="~/App_Data/Kentor.AuthServices.Tests.pfx" />
+  </serviceCertificates>
+  <!-- Optional configuration for fetching IDP list from a federation -->
   <federations>
     <add metadataLocation="https://federation.example.com/metadata.xml" allowUnsolicitedAuthnResponse = "false" />
   </federations>


### PR DESCRIPTION
Include serviceCertificate in the example configuration
Note that I made a comment above to highlight that it is optional.

Added the same kind of optional comment above the federations tag to make it obvious that it is optional too. Lots of people try to use the federations tag even if they only have one IDP, try to prevent that misconception.