### PR TITLE
Call the MessageUnbound notification on logout too

### DIFF
--- a/Kentor.AuthServices.Tests/WebSSO/LogoutCommandTests.cs
+++ b/Kentor.AuthServices.Tests/WebSSO/LogoutCommandTests.cs
@@ -238,11 +238,18 @@ namespace Kentor.AuthServices.Tests.WebSSO
             {
                 notifiedCommandResult = cr;
             };
+            var responseUnboundCalled = false;
+            options.Notifications.MessageUnbound = ur =>
+            {
+                ur.Should().NotBeNull();
+                responseUnboundCalled = true;
+            };
 
             var actual = CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
                 .Run(request, options);
 
             actual.Should().BeSameAs(notifiedCommandResult);
+            responseUnboundCalled.Should().BeTrue("the ResponseUnbound notification should have been called.");
 
             var expected = new CommandResult
             {

--- a/Kentor.AuthServices/Configuration/KentorAuthServicesNotifications.cs
+++ b/Kentor.AuthServices/Configuration/KentorAuthServicesNotifications.cs
@@ -67,7 +67,7 @@ namespace Kentor.AuthServices.Configuration
         public Func<HttpRequestData, Saml2Binding> GetBinding { get; set; }
 
         /// <summary>
-        /// Notification called when the ACS command has extracted data from
+        /// Notification called when the command has extracted data from
         /// request (by using <see cref="Saml2Binding.Unbind(HttpRequestData, IOptions)"/>)
         /// </summary>
         public Action<UnbindResult> MessageUnbound { get; set; }

--- a/Kentor.AuthServices/WebSSO/LogOutCommand.cs
+++ b/Kentor.AuthServices/WebSSO/LogOutCommand.cs
@@ -70,6 +70,8 @@ namespace Kentor.AuthServices.WebSso
             if (binding != null)
             {
                 var unbindResult = binding.Unbind(request, options);
+                options.Notifications.MessageUnbound(unbindResult);
+
                 VerifyMessageIsSigned(unbindResult, options);
                 switch (unbindResult.Data.LocalName)
                 {


### PR DESCRIPTION
So that it is consistent with how AcsCommand calls this notification after `Unbind`.