### PR TITLE
Compatibility setting and notifications for alternate logout state persistence

### DIFF
--- a/Kentor.AuthServices.Owin/CommandResultExtensions.cs
+++ b/Kentor.AuthServices.Owin/CommandResultExtensions.cs
@@ -55,7 +55,7 @@ namespace Kentor.AuthServices.Owin
         {
             var serializedCookieData = commandResult.GetSerializedRequestState();
 
-            if (serializedCookieData != null)
+            if (serializedCookieData != null && !string.IsNullOrEmpty(commandResult.SetCookieName))
             {
                 var protectedData = HttpRequestData.ConvertBinaryData(
                         dataProtector.Protect(serializedCookieData));

--- a/Kentor.AuthServices.Tests/Configuration/SPOptionsTests.cs
+++ b/Kentor.AuthServices.Tests/Configuration/SPOptionsTests.cs
@@ -23,6 +23,7 @@ namespace Kentor.AuthServices.Tests.Configuration
                 KentorAuthServicesSection.Current.Metadata.WantAssertionsSigned = false;
                 KentorAuthServicesSection.Current.Metadata.AllowChange = false;
                 KentorAuthServicesSection.Current.Compatibility.UnpackEntitiesDescriptorInIdentityProviderMetadata = false;
+                KentorAuthServicesSection.Current.Compatibility.DisableLogoutStateCookie = false;
                 KentorAuthServicesSection.Current.Compatibility.AllowChange = false;
             }
         }
@@ -63,6 +64,7 @@ namespace Kentor.AuthServices.Tests.Configuration
             config.ValidateCertificates = true;
             config.Compatibility.AllowChange = true;
             config.Compatibility.UnpackEntitiesDescriptorInIdentityProviderMetadata = true;
+            config.Compatibility.DisableLogoutStateCookie = true;
 
             SPOptions subject = new SPOptions(KentorAuthServicesSection.Current);
             subject.ReturnUrl.Should().Be(config.ReturnUrl);
@@ -80,6 +82,7 @@ namespace Kentor.AuthServices.Tests.Configuration
             subject.RequestedAuthnContext.ClassRef.OriginalString.Should().Be("urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport");
             subject.RequestedAuthnContext.Comparison.Should().Be(AuthnContextComparisonType.Minimum);
             subject.Compatibility.UnpackEntitiesDescriptorInIdentityProviderMetadata.Should().BeTrue();
+            subject.Compatibility.DisableLogoutStateCookie.Should().BeTrue();
         }
 
         [TestMethod]

--- a/Kentor.AuthServices.Tests/Owin/CommandResultExtensionsTests.cs
+++ b/Kentor.AuthServices.Tests/Owin/CommandResultExtensionsTests.cs
@@ -88,6 +88,32 @@ namespace Kentor.AuthServices.Tests.Owin
         }
 
         [TestMethod]
+        public void CommandResultExtensions_DoesNotApplyCookieWhenNoNameSet()
+        {
+            var cr = new CommandResult()
+            {
+                RequestState = new StoredRequestState(
+                    new EntityId("http://idp.example.com"),
+                    new Uri("http://sp.example.com/loggedout"),
+                    new Saml2Id("id123"),
+                    null),
+                SetCookieName = null
+            };
+
+            var context = OwinTestHelpers.CreateOwinContext();
+
+            var dataProtector = new StubDataProtector();
+            cr.Apply(context, dataProtector);
+
+            var setCookieHeader = context.Response.Headers["Set-Cookie"];
+
+            var protectedData = HttpRequestData.ConvertBinaryData(
+                StubDataProtector.Protect(cr.GetSerializedRequestState()));
+
+            setCookieHeader.Should().Be(null);
+        }
+
+        [TestMethod]
         public void CommandResultExtensions_Apply_ClearCookie()
         {
             var cr = new CommandResult()

--- a/Kentor.AuthServices.Tests/WebSSO/CommandResultTests.cs
+++ b/Kentor.AuthServices.Tests/WebSSO/CommandResultTests.cs
@@ -24,6 +24,7 @@ namespace Kentor.AuthServices.Tests.WebSso
                 Principal = (ClaimsPrincipal)null,
                 ContentType = (string)null,
                 Content = (string)null,
+                RelayState = (string)null,
                 RelayData = (object)null,
                 TerminateLocalSession = false,
                 SetCookieName = (string)null,

--- a/Kentor.AuthServices.Tests/WebSSO/LogoutCommandTests.cs
+++ b/Kentor.AuthServices.Tests/WebSSO/LogoutCommandTests.cs
@@ -110,10 +110,12 @@ namespace Kentor.AuthServices.Tests.WebSSO
             actual.ShouldBeEquivalentTo(expected, opt => opt
                 .Excluding(cr => cr.Location)
                 .Excluding(cr => cr.SetCookieName)
+                .Excluding(cr => cr.RelayState)
                 .Excluding(cr => cr.RequestState.MessageId));
 
             var relayState = HttpUtility.ParseQueryString(actual.Location.Query)["RelayState"];
             actual.SetCookieName.Should().Be("Kentor." + relayState);
+            actual.RelayState.Should().Be( relayState );
             actual.Location.GetLeftPart(UriPartial.Path).Should().Be("https://idp.example.com/logout");
         }
 
@@ -139,6 +141,33 @@ namespace Kentor.AuthServices.Tests.WebSSO
                 .Run(request, options);
 
             actual.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [TestMethod]
+        public void LogoutCommand_Run_NoCookieName_WhenLogoutStateDisabled()
+        {
+            var user = new ClaimsPrincipal(
+                new ClaimsIdentity(new Claim[]
+                {
+                    new Claim(AuthServicesClaimTypes.LogoutNameIdentifier, ",,,,NameId", null, "https://idp.example.com"),
+                    new Claim(AuthServicesClaimTypes.SessionIndex, "SessionId", null, "https://idp.example.com")
+                }, "Federation"));
+
+            var request = new HttpRequestData("GET", new Uri("http://sp-internal.example.com/AuthServices/Logout"));
+            request.User = user;
+
+            var options = StubFactory.CreateOptions();
+            options.SPOptions.ServiceCertificates.Add(SignedXmlHelper.TestCert);
+            options.SPOptions.PublicOrigin = new Uri("https://sp.example.com/");
+            options.SPOptions.Compatibility.DisableLogoutStateCookie = true;
+
+            var actual = CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+                .Run(request, options);
+
+            var relayState = HttpUtility.ParseQueryString(actual.Location.Query)["RelayState"];
+            actual.SetCookieName.Should().Be(null);
+            actual.RelayState.Should().Be( relayState );
+            actual.Location.GetLeftPart(UriPartial.Path).Should().Be("https://idp.example.com/logout");
         }
 
         [TestMethod]
@@ -204,6 +233,7 @@ namespace Kentor.AuthServices.Tests.WebSSO
             actual.ShouldBeEquivalentTo(expected, opt => opt
                 .Excluding(cr => cr.Location)
                 .Excluding(cr => cr.SetCookieName)
+                .Excluding(cr => cr.RelayState)
                 .Excluding(cr => cr.RequestState.MessageId));
             actual.Location.GetLeftPart(UriPartial.Path).Should().Be("https://idp.example.com/logout");
         }
@@ -730,6 +760,74 @@ namespace Kentor.AuthServices.Tests.WebSSO
             subject.Invoking(s => s.Run(request, options))
                 .ShouldThrow<NotImplementedException>()
                 .WithMessage("StubSaml2Binding.*");
+        }
+
+        [TestMethod]
+        public void LogoutCommand_Run_HandlesLogoutResponse_UsesApplicationPathWhenStateDisabled()
+        {
+            var response = new Saml2LogoutResponse(Saml2StatusCode.Success)
+            {
+                DestinationUrl = new Uri("http://sp.example.com/path/AuthServices/logout"),
+                Issuer = new EntityId("https://idp.example.com"),
+                InResponseTo = new Saml2Id(),
+                SigningCertificate = SignedXmlHelper.TestCert,
+                RelayState = null
+            };
+
+            var bindResult = Saml2Binding.Get(Saml2BindingType.HttpRedirect)
+                .Bind(response);
+
+            var applicationPath = "http://sp-internal.example.com/path/AuthServices/";
+            var request = new HttpRequestData("GET", bindResult.Location, applicationPath, null, null);
+
+            var options = StubFactory.CreateOptions();
+            options.SPOptions.Compatibility.DisableLogoutStateCookie = true;
+
+            var actual = CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+                .Run(request, options);
+
+            var expected = new CommandResult
+            {
+                Location = new Uri(applicationPath),
+                HttpStatusCode = HttpStatusCode.SeeOther,
+                ClearCookieName = null
+            };
+
+            actual.ShouldBeEquivalentTo(expected);
+        }
+
+        [TestMethod]
+        public void LogoutCommand_Run_HandlesLogoutResponse_UsesReturnPathWhenStateDisabled()
+        {
+            var response = new Saml2LogoutResponse(Saml2StatusCode.Success)
+            {
+                DestinationUrl = new Uri("http://sp.example.com/path/AuthServices/logout"),
+                Issuer = new EntityId("https://idp.example.com"),
+                InResponseTo = new Saml2Id(),
+                SigningCertificate = SignedXmlHelper.TestCert,
+                RelayState = null
+            };
+
+            var bindResult = Saml2Binding.Get(Saml2BindingType.HttpRedirect)
+                .Bind(response);
+
+            var applicationPath = "http://sp-internal.example.com/path/AuthServices/";
+            var returnPath = "http://sp-internal.example.com/path/anotherpath";
+            var request = new HttpRequestData("GET", bindResult.Location, applicationPath, null, null);
+
+            var options = StubFactory.CreateOptions();
+            options.SPOptions.Compatibility.DisableLogoutStateCookie = true;
+
+            var actual = LogoutCommand.Run(request, returnPath, options);
+
+            var expected = new CommandResult
+            {
+                Location = new Uri( returnPath ),
+                HttpStatusCode = HttpStatusCode.SeeOther,
+                ClearCookieName = null
+            };
+
+            actual.ShouldBeEquivalentTo(expected);
         }
     }
 }

--- a/Kentor.AuthServices/Configuration/Compatibility.cs
+++ b/Kentor.AuthServices/Configuration/Compatibility.cs
@@ -31,6 +31,7 @@ namespace Kentor.AuthServices.Configuration
 
             UnpackEntitiesDescriptorInIdentityProviderMetadata =
                 configElement.UnpackEntitiesDescriptorInIdentityProviderMetadata;
+            DisableLogoutStateCookie = configElement.DisableLogoutStateCookie;
         }
 
         /// <summary>
@@ -39,5 +40,12 @@ namespace Kentor.AuthServices.Configuration
         /// is a single EntityDescriptor and in that case use it.
         /// </summary>
         public bool UnpackEntitiesDescriptorInIdentityProviderMetadata { get; set; }
+
+        /// <summary>
+        /// Do not send logout state cookie, e.g. if you are not using ReturnUrl
+        /// or if you know the cookie will be lost due to cross-domain redirects
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage( "Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "Logout" )]
+        public bool DisableLogoutStateCookie { get; set; }
     }
 }

--- a/Kentor.AuthServices/Configuration/CompatibilityElement.cs
+++ b/Kentor.AuthServices/Configuration/CompatibilityElement.cs
@@ -44,5 +44,26 @@ namespace Kentor.AuthServices.Configuration
                 base[unpackEntitiesDescriptorInIdentityProviderMetadata] = value;
             }
         }
+
+        const string disableLogoutStateCookie
+            = nameof(disableLogoutStateCookie);
+
+        /// <summary>
+        /// Do not send logout state cookie, e.g. if you are not using ReturnUrl
+        /// or if you know the cookie will be lost due to cross-domain redirects
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage( "Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "Logout" )]
+        [ConfigurationProperty(nameof(disableLogoutStateCookie), IsRequired = false)]
+        public bool DisableLogoutStateCookie
+        {
+            get
+            {
+                return (bool)base[disableLogoutStateCookie];
+            }
+            set
+            {
+                base[disableLogoutStateCookie] = value;
+            }
+        }
     }
 }

--- a/Kentor.AuthServices/Configuration/KentorAuthServicesNotifications.cs
+++ b/Kentor.AuthServices/Configuration/KentorAuthServicesNotifications.cs
@@ -21,6 +21,7 @@ namespace Kentor.AuthServices.Configuration
             AuthenticationRequestCreated = (request, provider, dictionary) => { };
             SignInCommandResultCreated = (cr, r) => { };
             SelectIdentityProvider = (ei, r) => null;
+            GetLogoutResponseState = ( httpRequestData ) => httpRequestData.StoredRequestState;
             GetBinding = Saml2Binding.Get;
             MessageUnbound = ur => { };
             AcsCommandResultCreated = (cr, r) => { };
@@ -59,6 +60,17 @@ namespace Kentor.AuthServices.Configuration
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
         public Func<EntityId, IDictionary<string, string>, IdentityProvider>
             SelectIdentityProvider { get; set; }
+
+        /// <summary>
+        /// Notification called when the logout command is about to use the 
+        /// <code>StoredRequestState</code> derived from the request's RelayState data.
+        /// Return a different StoredRequestState if you would like to customize the 
+        /// RelayState lookup. 
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "Logout")]
+        public Func<HttpRequestData, StoredRequestState>
+            GetLogoutResponseState { get; set; }
 
         /// <summary>
         /// Get a binding that can unbind data from the supplied request. The

--- a/Kentor.AuthServices/WebSSO/CommandResult.cs
+++ b/Kentor.AuthServices/WebSSO/CommandResult.cs
@@ -70,6 +70,11 @@ namespace Kentor.AuthServices.WebSso
         public string SetCookieName { get; set; }
 
         /// <summary>
+        /// SAML RelayState value
+        /// </summary>
+        public string RelayState { get; set; }
+
+        /// <summary>
         /// Request state to store so that it is available on next http request.
         /// </summary>
         public StoredRequestState RequestState { get; set; }

--- a/Kentor.AuthServices/WebSSO/HttpRequestData.cs
+++ b/Kentor.AuthServices/WebSSO/HttpRequestData.cs
@@ -101,6 +101,7 @@ namespace Kentor.AuthServices.WebSso
             {
                 Form.TryGetValue("RelayState", out relayState);
             }
+            RelayState = relayState;
 
             if (relayState != null)
             {
@@ -182,6 +183,10 @@ namespace Kentor.AuthServices.WebSso
         /// </summary>
         public Uri ApplicationUrl { get; set; }
 
+        /// <summary>
+        /// RelayState from SAML message
+        /// </summary>
+        public string RelayState { get; set; }
 
         /// <summary>
         /// Request state from a previous call, carried over through cookie.


### PR DESCRIPTION
Fixes #509 by allowing the developer to disable the logout state cookies, while exposing the RelayState value so they can use an alternate approach (e.g. database lookup) for the `StoredRequestState`