### PR TITLE
Notification hook for per-request public origin

### DIFF
--- a/Kentor.AuthServices.Owin/KentorAuthServicesAuthenticationHandler.cs
+++ b/Kentor.AuthServices.Owin/KentorAuthServicesAuthenticationHandler.cs
@@ -98,7 +98,7 @@ namespace Kentor.AuthServices.Owin
             if (revoke != null)
             {
                 var request = await Context.ToHttpRequestData(Options.DataProtector.Unprotect);
-                var urls = new AuthServicesUrls(request, Options.SPOptions);
+                var urls = new AuthServicesUrls(request, Options);
 
                 string redirectUrl = revoke.Properties.RedirectUri;
                 if (string.IsNullOrEmpty(redirectUrl))

--- a/Kentor.AuthServices/Configuration/KentorAuthServicesNotifications.cs
+++ b/Kentor.AuthServices/Configuration/KentorAuthServicesNotifications.cs
@@ -22,6 +22,7 @@ namespace Kentor.AuthServices.Configuration
             SignInCommandResultCreated = (cr, r) => { };
             SelectIdentityProvider = (ei, r) => null;
             GetLogoutResponseState = ( httpRequestData ) => httpRequestData.StoredRequestState;
+            GetPublicOrigin = ( httpRequestData ) => null;
             GetBinding = Saml2Binding.Get;
             MessageUnbound = ur => { };
             AcsCommandResultCreated = (cr, r) => { };
@@ -71,6 +72,15 @@ namespace Kentor.AuthServices.Configuration
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1726:UsePreferredTerms", MessageId = "Logout")]
         public Func<HttpRequestData, StoredRequestState>
             GetLogoutResponseState { get; set; }
+
+        /// <summary>
+        /// Notification called when a command is about to construct a fully-qualified url
+        /// Return a non-null Uri if you need to override this per request. Otherwise
+        /// it will fall back to the normal logic that checks the request Uri 
+        /// and the SPOptions.PublicOrigin setting
+        /// </summary>
+        public Func<HttpRequestData, Uri>
+            GetPublicOrigin { get; set; }
 
         /// <summary>
         /// Get a binding that can unbind data from the supplied request. The

--- a/Kentor.AuthServices/Configuration/SPOptions.cs
+++ b/Kentor.AuthServices/Configuration/SPOptions.cs
@@ -179,7 +179,8 @@ namespace Kentor.AuthServices.Configuration
         /// application root path from the HTTP request when creating links. 
         /// This might not be accurate in reverse proxy or load-balancing
         /// situations. You can override the origin used for link generation
-        /// using this property.
+        /// for the entire application using this property. To override per request,
+        /// implement a <code>GetPublicOrigin</code> Notification function.
         /// </summary>
         public Uri PublicOrigin { get; set; }
 

--- a/Kentor.AuthServices/WebSSO/AuthServicesUrls.cs
+++ b/Kentor.AuthServices/WebSSO/AuthServicesUrls.cs
@@ -16,21 +16,22 @@ namespace Kentor.AuthServices.WebSso
         /// Resolve the urls for AuthServices from an http request and options.
         /// </summary>
         /// <param name="request">Request to get application root url from.</param>
-        /// <param name="spOptions">SP Options to get module path from.</param>
+        /// <param name="options">Options to get module path and (optional) notification hooks from.</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2208:InstantiateArgumentExceptionsCorrectly"), System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "sp")]
-        public AuthServicesUrls(HttpRequestData request, SPOptions spOptions)
+        public AuthServicesUrls(HttpRequestData request, IOptions options)
         {
             if (request == null)
             {
                 throw new ArgumentNullException(nameof(request));
             }
 
-            if (spOptions == null)
+            if (options == null)
             {
-                throw new ArgumentNullException(nameof(spOptions));
+                throw new ArgumentNullException(nameof(options));
             }
 
-            Init(request.ApplicationUrl, spOptions);
+            var publicOrigin = options.Notifications.GetPublicOrigin(request) ?? options.SPOptions.PublicOrigin ?? request.ApplicationUrl;
+            Init(publicOrigin, options.SPOptions.ModulePath);
         }
 
         /// <summary>
@@ -93,12 +94,6 @@ namespace Kentor.AuthServices.WebSso
             SignInUrl = new Uri(authServicesRoot + CommandFactory.SignInCommandName);
             ApplicationUrl = publicOrigin;
             LogoutUrl = new Uri(authServicesRoot + CommandFactory.LogoutCommandName);
-        }
-
-        void Init(Uri applicationUrl, SPOptions spOptions)
-        {
-            var publicOrigin = spOptions.PublicOrigin ?? applicationUrl;
-            Init(publicOrigin, spOptions.ModulePath);
         }
 
         /// <summary>

--- a/Kentor.AuthServices/WebSSO/LogOutCommand.cs
+++ b/Kentor.AuthServices/WebSSO/LogOutCommand.cs
@@ -175,7 +175,7 @@ namespace Kentor.AuthServices.WebSso
             }
             else
             {
-                return new AuthServicesUrls(request, options.SPOptions).ApplicationUrl;
+                return new AuthServicesUrls(request, options).ApplicationUrl;
             }
         }
 

--- a/Kentor.AuthServices/WebSSO/MetadataCommand.cs
+++ b/Kentor.AuthServices/WebSSO/MetadataCommand.cs
@@ -21,7 +21,7 @@ namespace Kentor.AuthServices.WebSso
                 throw new ArgumentNullException(nameof(options));
             }
 
-            var urls = new AuthServicesUrls(request, options.SPOptions);
+            var urls = new AuthServicesUrls(request, options);
 
             var metadata = options.SPOptions.CreateMetadata(urls);
             options.Notifications.MetadataCreated(metadata, urls);

--- a/Kentor.AuthServices/WebSSO/SignInCommand.cs
+++ b/Kentor.AuthServices/WebSSO/SignInCommand.cs
@@ -70,7 +70,7 @@ namespace Kentor.AuthServices.WebSso
                 throw new ArgumentNullException(nameof(options));
             }
 
-            var urls = new AuthServicesUrls(request, options.SPOptions);
+            var urls = new AuthServicesUrls(request, options);
 
             IdentityProvider idp = options.Notifications.SelectIdentityProvider(idpEntityId, relayData);
             if (idp == null)

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -174,6 +174,9 @@ with load balancers or reverse proxies. It can also be used if the application
 can be accessed by several external URLs to make sure that the registered in
 metadata is used in communication with the Idp.
 
+If you need to set this value on a per-request basis, provide a GetPublicOrigin
+Notification function instead.
+
 ###`<nameIdPolicy>` Element
 *Optional child element of the [`<kentor.authServices>`](#kentor-authservices-section) element.*
 


### PR DESCRIPTION
As mentioned [here](https://github.com/KentorIT/authservices/issues/340#issuecomment-173751893) by @Peperud and from my own experience, it's sometimes required to compute the public origin on a per-request basis rather than simply configuring one value for the whole site. IdentityServer3 has a mechanism for setting this per-request (via OWIN environment extension) but if you use AuthServices as an external identity middleware then it only has the single PublicOrigin setting.

This PR adds a Notification hook for providing this value. Unfortunately it also meant supplying `IOptions` rather than `SPOptions` to `AuthServicesUrls`, which would be a **breaking change** since that's a public constructor.