### PR TITLE
Switch users on idp-initiated requests.

### DIFF
--- a/Kentor.AuthServices.Owin/KentorAuthServicesAuthenticationHandler.cs
+++ b/Kentor.AuthServices.Owin/KentorAuthServicesAuthenticationHandler.cs
@@ -133,7 +133,21 @@ namespace Kentor.AuthServices.Owin
             {
                 if(remainingPath == new PathString("/" + CommandFactory.AcsCommandName))
                 {
+                    var localUser = this.TryGetLocalUser(Options.SPOptions.ModulePath.Substring(1));
                     var ticket = (MultipleIdentityAuthenticationTicket)await AuthenticateAsync();
+
+                    if (localUser != null)
+                    {
+                        var externalNameIdentifier = ticket.Identity.ToSaml2NameIdentifier();
+
+                        if (externalNameIdentifier.Value != localUser.Item2)
+                        {
+                            // Sign out the local user (on identity server) if they are not the same
+                            // newly authenticated user.
+                            Context.Authentication.SignOut(localUser.Item1.AuthenticationType);
+                        }
+                    }
+
                     Context.Authentication.SignIn(ticket.Properties, ticket.Identities.ToArray());
                     // No need to redirect here. Command result is applied in AuthenticateCoreAsync.
                     return true;
@@ -178,6 +192,32 @@ namespace Kentor.AuthServices.Owin
                 externalLogutNameIdClaim.Value,
                 externalLogutNameIdClaim.ValueType,
                 externalLogutNameIdClaim.Issuer));
+        }
+
+        private Tuple<ClaimsIdentity, string> TryGetLocalUser(string idp)
+        {
+            var user = Context.Authentication.User;
+
+            if (null != user)
+            {
+                var localUser = user.Identities
+                    .Where(x => x.Claims.Any(c => c.Type == "idp" && c.Value == idp))
+                    .FirstOrDefault();
+
+                if (localUser != null)
+                {
+                    var logoutClaim = localUser.Claims.Where(x => x.Type == AuthServicesClaimTypes.LogoutNameIdentifier)
+                        .FirstOrDefault();
+
+                    if (logoutClaim != null)
+                    {
+                        var nameIdentifier = logoutClaim.ToSaml2NameIdentifier();
+                        return new Tuple<ClaimsIdentity, string>(localUser, nameIdentifier.Value);
+                    }
+                }
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
We have IdentityServer3 and AuthServices setup with a couple of Okta accounts as per https://github.com/KentorIT/authservices/blob/master/doc/IdentityServer3Okta.md.

This works perfectly when the flow is SP initiated (from IdentityServer). However, this scenario currently does not work correctly:

 - Log into Okta using user 'Bill'
 - Click the application icon on Bill's Okta dashboard to start the IDP-initiated sign in request
 - The redirect dance starts and 'Bill' is logged in correctly
 - Go back to Okta, log 'Bill' out and login as Ben'
 - Click the application icon on Ben's Okta dashboard to start the IDP-initiated sign in request
 - The redirect dance starts, completes but the logged in user is still 'Bill' (not 'Ben')

The problem only seems to occur when 1/ using the IDP-initiated flow and 2/ you're currently logged in from the same Okta account (IDP) as another user in IdentityServer.

If you logout of IdentityServer or login using a different IDP, this works fine.

SP-initiated requests from the IdentityServer External Sign-in buttons don't have this issue and work correctly.

I've spent a couple of days tracing to try and understand what's happening.

As far as I can tell, AuthServices correctly processes the incoming IDP-initiated request and calls Context.Authentication.SignIn() with the correct ClaimsIdentity (the idsrv.external cookie gets set).

However, IdentityServer doesn't process this (the IUserService implementation isn't called to create the local user). I think this is because it's expecting to receive a call to its http://localhost/identityserver/core/callback URL (which doesn't happen since AuthServices redirects to the client application directly).

IdentityServer just sees the currently logged in user (idsrv cookie) as from the correct IDP and assumes the correct user is already logged in - I think ;)

A quick and dirty hack is just to logout the local identity server user in KentorAuthServicesAuthenticationHandler.InvokeAsync() so that IdentityServer will effectively trigger an SP-initiated flow.

```c#
public override async Task<bool> InvokeAsync()
{
	var authServicesPath = new PathString(Options.SPOptions.ModulePath);
	PathString remainingPath;

	if(Request.Path.StartsWithSegments(authServicesPath, out remainingPath))
	{
		if(remainingPath == new PathString("/" + CommandFactory.AcsCommandName))
		{
			var ticket = (MultipleIdentityAuthenticationTicket)await AuthenticateAsync();

			//-----------------
			// Hack to sign out the current local user on IdentityServer
			Context.Authentication.SignOut("idsrv");
			//-----------------
			Context.Authentication.SignIn(ticket.Properties, ticket.Identities.ToArray());
			// No need to redirect here. Command result is applied in AuthenticateCoreAsync.
			return true;
		}

		var result = CommandFactory.GetCommand(remainingPath.Value)
			.Run(await Context.ToHttpRequestData(Options.DataProtector.Unprotect), Options);

		if (!result.HandledResult)
		{
			result.Apply(Context, Options.DataProtector);
		}

		return true;
	}

	return false;
}
```

Obviously this is not ideal. I thought that perhaps the user should be signed out if they are from the same IDP and they're *not* the user in the IDP-initiated request, but in a generic way without hardcoding the "idsrv" AuthenticationType.

This pull request is a first stab at this and works well enough for our requirements here.

Thanks for your time.