### PR TITLE
Add UnsolicitedAuthnResponseReceived notification

### DIFF
--- a/Kentor.AuthServices/Configuration/KentorAuthServicesNotifications.cs
+++ b/Kentor.AuthServices/Configuration/KentorAuthServicesNotifications.cs
@@ -25,6 +25,7 @@ namespace Kentor.AuthServices.Configuration
             GetPublicOrigin = ( httpRequestData ) => null;
             GetBinding = Saml2Binding.Get;
             MessageUnbound = ur => { };
+            UnsolicitedAuthnResponseReceived = (cr, r) => { };
             AcsCommandResultCreated = (cr, r) => { };
             LogoutCommandResultCreated = cr => { };
             MetadataCreated = (md, urls) => { };
@@ -93,6 +94,15 @@ namespace Kentor.AuthServices.Configuration
         /// request (by using <see cref="Saml2Binding.Unbind(HttpRequestData, IOptions)"/>)
         /// </summary>
         public Action<UnbindResult> MessageUnbound { get; set; }
+
+        /// <summary>
+        /// Notification called when the ACS command has produced a
+        /// <see cref="CommandResult"/> after receiving an unsolicited Authn response,
+        /// but before anything has been applied to the outgoing response. Set the
+        /// <see cref="CommandResult.HandledResult"/> flag to suppress the library's built
+        /// in apply functionality to the outgoing response.
+        /// </summary>
+        public Action<CommandResult, Saml2Response> UnsolicitedAuthnResponseReceived { get; set; }
 
         /// <summary>
         /// Notification called when the ACS command has produced a

--- a/Kentor.AuthServices/WebSSO/AcsCommand.cs
+++ b/Kentor.AuthServices/WebSSO/AcsCommand.cs
@@ -46,6 +46,12 @@ namespace Kentor.AuthServices.WebSso
                     {
                         result.ClearCookieName = "Kentor." + unbindResult.RelayState;
                     }
+
+                    if (request.StoredRequestState == null)
+                    {
+                        options.Notifications.UnsolicitedAuthnResponseReceived(result, samlResponse);
+                    }
+
                     options.Notifications.AcsCommandResultCreated(result, samlResponse);
                     return result;
                 }


### PR DESCRIPTION
Based on feedback in #613, this pull request adds support for a new `UnsolicitedAuthnResponseReceived ` notification.

The notification is triggered by the AcsCommand after processing the request but before the existing `AcsCommandResultCreated` notification.

The issue in #613 can then be worked around in the host application.