### PR TITLE
Allows for cookie lifetime to be set by persistentSessionLifetime

### DIFF
--- a/Kentor.AuthServices.HttpModule/CommandResultHttpExtension.cs
+++ b/Kentor.AuthServices.HttpModule/CommandResultHttpExtension.cs
@@ -124,7 +124,10 @@ namespace Kentor.AuthServices.HttpModule
                     null,
                     DateTime.UtcNow,
                     commandResult.SessionNotOnOrAfter ??
-                    CalculateSessionNotOnOrAfter());
+                    CalculateSessionNotOnOrAfter())
+                {
+                    IsPersistent = true
+                };
 
                 EnsureSessionAuthenticationModuleAvailable();
 


### PR DESCRIPTION
Resolves #242. Allows for cookie lifetime to be set by persistentSessionLifetime of cookieHandler in federationConfiguration.